### PR TITLE
docs: clarify integration paths, OData targeting params, and test-mode default

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -59,7 +59,7 @@ export default defineConfig({
             ],
           },
           {
-            text: "Publisher Integration",
+            text: "Custom Publisher Integration",
             link: "/integration-guide/publisher-integration/overview",
             collapsed: true,
             items: [
@@ -153,7 +153,7 @@ export default defineConfig({
                 link: "/integration-guide/partner-integration/shopify-ad-unit-preact",
               },
               {
-                text: "Complete Integration Example",
+                text: "Complete Custom Integration Example",
                 link: "/integration-guide/partner-integration/complete-integration-example",
               },
               {

--- a/integration-guide/_shared/odata-api.md
+++ b/integration-guide/_shared/odata-api.md
@@ -25,7 +25,7 @@ Authorization: Bearer PUBLIC_KEY
 ### Required Parameters
 
 - `placementId` (string): Placement ID from placement creation
-- `sessionId` (string): Unique session identifier for the customer (can use email, hashed email, or orderId)
+- `sessionId` (string): Unique session identifier for the customer (e.g., email or hashed email — distinct from `at.orderid`, which represents a specific order)
 - `at.email` (string): Customer email address (plain or SHA-256 hashed)
 - `at.orderid` (string): Order ID
 - `at.clientIp` (string): Client IP address (IPv4 or IPv6) — used for geo-targeting

--- a/integration-guide/_shared/odata-api.md
+++ b/integration-guide/_shared/odata-api.md
@@ -28,8 +28,12 @@ Authorization: Bearer PUBLIC_KEY
 - `sessionId` (string): Unique session identifier for the customer (can use email, hashed email, or orderId)
 - `at.email` (string): Customer email address (plain or SHA-256 hashed)
 - `at.orderid` (string): Order ID
+- `at.clientIp` (string): Client IP address (IPv4 or IPv6) — used for geo-targeting
+- `at.userAgent` (string): Client user agent string (max 500 chars) — used for device detection
 
 > Note: At minimum, you must provide placementId, sessionId, and either at.email or at.orderid for proper tracking.
+
+> Proxying through a server: If you call OData from a backend or proxy rather than directly from the end user's browser, the request's source IP and User-Agent header will be your server's, not the customer's. In that case you must read the original client IP from the `X-Forwarded-For` header (typically the first IP in the list) and the original `User-Agent` header from the inbound request, and forward them explicitly via `at.clientIp` and `at.userAgent`. Otherwise every request will appear to come from your server, breaking geo and device targeting for all users.
 
 ### Optional Parameters
 
@@ -63,11 +67,6 @@ Pass customer and order data with the `at.` prefix for better targeting and anal
 - `at.billingzipcode` (string): Billing ZIP code (max 20 chars)
 - `at.paymenttype` or `at.payment_type` (string): Payment method
 - Valid values: `creditCard`, `debitCard`, `paypal`, `applePay`, `googlePay`, `bankTransfer`, `crypto`, `other`
-
-**Client Context:**
-
-- `at.clientIp` (string): Client IP address override (IPv4 or IPv6, used for geo-targeting)
-- `at.userAgent` (string): Client user agent override (max 500 chars, used for device detection)
 
 **Supported Currencies:**
 USD, EUR, GBP, CAD, AUD, JPY, CNY, NZD, CHF, SEK, NOK, DKK, PLN, CZK, HUF, RON, BGN, HRK, RUB, TRY, BRL, MXN, ARS, CLP, COP, PEN, UYU, INR, IDR, MYR, PHP, SGD, THB, VND, KRW, HKD, TWD, SAR, AED, ILS, EGP, ZAR, NGN, KES, GHS

--- a/integration-guide/partner-integration/best-practices.md
+++ b/integration-guide/partner-integration/best-practices.md
@@ -22,10 +22,10 @@
 
 ### 4. Testing
 
-- Always test in **test mode** (`isLiveMode: false`) before going live
+- All initial development and testing should happen on the [Staging Environment](./staging-environment) — production credentials are only issued after a successful staging review.
+- Newly created placements default to **test mode** (`isLiveMode: false`), which returns mock offers from OData. This is the expected default on staging and for initial UA / test stores in production. Real production publishers must explicitly pass `isLiveMode: true` when creating the placement (or update it later via the [Placements API](./placements-api)) — forgetting this is the most common reason real offers don't appear.
 - Verify ad display and tracking are working correctly
 - Test error scenarios and edge cases
-- Use the sandbox environment if available
 
 ### 5. Performance
 
@@ -47,5 +47,10 @@
 - Monitor rate limit consumption
 - Set up alerts for critical errors
 - Review reporting data regularly to optimize performance
+
+### 8. Client Context for Targeting
+
+- Always pass `at.clientIp` and `at.userAgent` on OData requests. Without them, geo and device targeting are disabled, which significantly degrades offer relevance and placement performance.
+- If you call OData from a backend or proxy rather than directly from the customer's browser, read the original client IP from the `X-Forwarded-For` header (typically the first entry) and the original `User-Agent` from the inbound request, and forward them via the `at.` parameters. Otherwise every request appears to come from your server and targeting breaks for all users.
 
 ---

--- a/integration-guide/partner-integration/complete-integration-example.md
+++ b/integration-guide/partner-integration/complete-integration-example.md
@@ -1,6 +1,8 @@
-## Complete Integration Example
+## Complete Custom Integration Example
 
-Here’s a complete workflow for integrating a store:
+This is a complete walkthrough of the **custom integration path** — creating the entity hierarchy as a partner, then rendering offers yourself by calling OData directly and wiring up the click and impression URLs returned in the response. If you have full control over the surface and don't need to customize rendering, prefer the [Embedded Web SDK](/integration-guide/embedded) — it handles fetching, rendering, impression tracking, and click handling for you. This guide is for cases where you're rendering offers in your own UI.
+
+### 1. Create the entity hierarchy
 
 ```bash
 #!/bin/bash
@@ -42,7 +44,7 @@ SITE_RESPONSE=$(curl -s -X POST "${BASE_URL}/api/site" \
 SITE_ID=$(echo $SITE_RESPONSE | jq -r '.data.id')
 echo "Site ID:$SITE_ID"
 
-# Step 3: Create Placement
+# Step 3: Create Placement (defaults to test mode)
 echo ""
 echo "Step 3: Creating placement..."
 PLACEMENT_RESPONSE=$(curl -s -X POST "${BASE_URL}/api/placements" \
@@ -57,11 +59,16 @@ PLACEMENT_RESPONSE=$(curl -s -X POST "${BASE_URL}/api/placements" \
 
 PLACEMENT_ID=$(echo $PLACEMENT_RESPONSE | jq -r '.data.id')
 echo "Placement ID:$PLACEMENT_ID"
+```
 
-# Step 4: Test fetching offers
+> Test mode reminder: Step 3 omits `isLiveMode` (defaulting to `false`), which puts the placement in **test mode** — OData will return mock offers, not real ones from the network. Production publishers that should serve real offers must pass `isLiveMode: true`. See the [Placements API](./placements-api) for details.
+
+### 2. Fetch offers via OData
+
+```bash
 echo ""
-echo "Step 4: Testing offer retrieval..."
-curl -s -X GET "${BASE_URL}/api/odata?placementId=${PLACEMENT_ID}&sessionId=test_session_123&count=4" \
+echo "Step 4: Fetching offers..."
+curl -s -X GET "${BASE_URL}/api/odata?placementId=${PLACEMENT_ID}&sessionId=test_session_123&count=4&at.email=customer@example.com&at.orderid=ORDER-12345&at.clientIp=203.0.113.42&at.userAgent=Mozilla%2F5.0" \
   -H "Authorization: Bearer${PUBLIC_KEY}" | jq '.'
 
 echo ""
@@ -70,3 +77,53 @@ echo "Public Key:$PUBLIC_KEY"
 echo "Private Key:$PRIVATE_KEY"
 echo "Placement ID:$PLACEMENT_ID"
 ```
+
+Each offer in the response includes three URLs you'll wire up in the next step:
+
+- `clickUrl` — navigate the customer here when they click the offer
+- `beaconUrl` — call this when the offer becomes visible (impression)
+- `closeUrl` — call this when the customer dismisses the offer
+
+> Backend proxy reminder: If your backend is calling OData on behalf of the browser, pass the customer's real IP and User-Agent via `at.clientIp` (read from `X-Forwarded-For`, typically the first entry) and `at.userAgent` (read from the inbound `User-Agent` header). Without these, every request looks like it's coming from your server and geo/device targeting breaks for all users.
+
+See the [OData API](./odata-api) docs for the full response shape and parameter reference.
+
+### 3. Render offers and wire up impression + click tracking
+
+Once you have the offer payload, render each offer in your UI and:
+
+1. **Fire the impression beacon (`beaconUrl`)** the first time the offer becomes visible to the customer.
+2. **Use the click URL (`clickUrl`)** as the navigation target when the customer clicks the offer's CTA — that endpoint records the click and redirects to the advertiser.
+
+A minimal browser-side example (framework-agnostic):
+
+```js
+// `offers` is the `offers` array from the OData response.
+function renderOffer(offer, container) {
+  const card = document.createElement("a");
+  card.href = offer.clickUrl;          // wraps the offer in the click URL
+  card.rel = "noopener";
+  card.innerHTML = `
+    <h3>${offer.title}</h3>
+    <p>${offer.description}</p>
+    <button>${offer.ctaText}</button>
+  `;
+
+  // Fire the impression beacon the first time the card is on screen.
+  const observer = new IntersectionObserver((entries, obs) => {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        navigator.sendBeacon(offer.beaconUrl);   // impression
+        obs.disconnect();
+      }
+    }
+  }, { threshold: 0.5 });
+  observer.observe(card);
+
+  container.appendChild(card);
+}
+```
+
+> Important: Skipping the impression beacon means Falcon never records that the offer was viewed, which breaks attribution and reporting. Skipping the click URL means clicks aren't recorded and the customer won't be redirected to the advertiser. Both are required for a custom integration to be considered complete.
+
+For the full event semantics — including the JSON variants and required parameters — see the [Impression API](./impression-api) and [Click API](./click-api) docs.

--- a/integration-guide/partner-integration/frequently-asked-questions.md
+++ b/integration-guide/partner-integration/frequently-asked-questions.md
@@ -14,7 +14,7 @@
 
 ### Q: How do I customize the appearance of offers?
 
-**A**: For Shopify integrations, use the Adjustable Template component with the 84 configuration parameters. For other platforms, implement your own rendering using the offer data from the OData API.
+**A**: For Shopify Checkout, use our maintained ad unit components — see [Shopify Ad Unit (React)](./shopify-ad-unit-react) or [Shopify Ad Unit (Preact)](./shopify-ad-unit-preact). For surfaces where you control the page, use the [Embedded Web SDK](/integration-guide/embedded). If you need full control over rendering, call [OData](./odata-api) directly and render the offer data yourself — but remember you'll then own firing impressions and wrapping CTAs in the click URL (see the [Complete Custom Integration Example](./complete-integration-example)).
 
 ### Q: How long are offers valid?
 
@@ -31,3 +31,15 @@
 ### Q: Do I need to implement impression tracking?
 
 **A**: Yes, call the `beaconUrl` when an offer is displayed to track impressions. This is critical for accurate reporting and campaign optimization.
+
+### Q: Why am I only seeing test/mock offers instead of real ones?
+
+**A**: Your placement is in **test mode**. Newly created placements default to `isLiveMode: false`, which returns mock offers — that's the expected default on staging and for initial UA / test stores. To serve real offers from the Falcon network, set `isLiveMode: true` when creating the placement, or update an existing placement via the [Placements API](./placements-api).
+
+### Q: Should I call OData from my backend or directly from the browser?
+
+**A**: Either works. If you call directly from the browser, the customer's IP and User-Agent are picked up automatically. If you proxy through a backend, the request's source IP and User-Agent will be your server's, not the customer's — you must read the original client IP from the `X-Forwarded-For` header (typically the first entry) and the original `User-Agent` from the inbound request, and forward them via the `at.clientIp` and `at.userAgent` parameters. Without this, geo and device targeting break for every user.
+
+### Q: What's the difference between staging and production?
+
+**A**: Staging (`https://staging-pr-api.falconlabs.us`) is for initial development and end-to-end verification of your integration; production credentials are only issued after a successful staging review. All early development and testing must happen on staging to avoid polluting production metrics. See the [Staging Environment](./staging-environment) page for details.

--- a/integration-guide/partner-integration/overview.md
+++ b/integration-guide/partner-integration/overview.md
@@ -2,10 +2,40 @@
 
 ## Overview
 
-This guide provides comprehensive instructions for integrating Falcon’s promotional ad unit system into your platform. Falcon enables partners to display targeted promotional offers to customers at key moments in their journey (thank you pages, order status pages, etc.).
+This guide provides comprehensive instructions for integrating Falcon's promotional ad unit system into your platform. Falcon enables partners to display targeted promotional offers to customers at key moments in their journey (thank you pages, order status pages, etc.).
 
-The integration follows a three-step process:
+Before you begin, review the [Prerequisites](./prerequisites) for the credentials and access you'll need. All initial development and testing should happen against the [Staging Environment](./staging-environment), which is meant for verifying your integration end-to-end without polluting production metrics — production credentials are issued only after a successful staging review.
 
-1. **Create a Publisher** - Represents a store owner/merchant in Falcon’s system
-2. **Create a Site** - Represents an individual store/website
-3. **Create a Placement** - Represents the specific ad unit location (e.g., thank you page)
+A partner integration has two parts: standing up the entity hierarchy that represents your portfolio, and then serving ads against it.
+
+### 1. Setting up the entity hierarchy
+
+Falcon's data model is hierarchical. You'll create three entities in succession, each via its own API:
+
+- **Publishers** represent the companies in your portfolio that can host advertisements (typically a merchant or store owner). Create them via the [Publishers API](./publishers-api).
+- **Sites** represent unique domains or stores within a publisher's portfolio. In many cases a publisher will only have a single site, but the model supports multiple. Create them via the [Sites API](./sites-api).
+- **Placements** represent unique pages or opportunities within a site where ads can be served — for example, the thank you page or the order status page. Create them via the [Placements API](./placements-api).
+
+Each API is leveraged to build its corresponding object in order: publisher → site(s) under that publisher → placement(s) under each site.
+
+### 2. Serving ads
+
+Once you've created placements under the sites and publishers you want to display ads for, the last step is actually serving the ads. The right approach depends on how much control you have over the surface.
+
+#### Embedded Web SDK (recommended)
+
+On any surface where you have full control over the rendered HTML, we highly recommend leveraging our [Embedded Web SDK](/integration-guide/embedded). Drop it in with the public token and the `placementId` you generated in the steps above, and the SDK handles fetching, rendering, impression tracking, and click handling for you.
+
+#### Shopify checkout
+
+Within the Shopify world there are restrictions on the types of components that can render in the Checkout Flow, so the standard Embedded SDK isn't usable there. For those surfaces we maintain GitHub repos for both React and Preact git submodules that you can import into your codebase and leverage to do all the heavy lifting of generating the look and feel, managing the carousel, wrapping the components in click URLs, and firing impressions.
+
+- [Shopify Ad Unit (React)](./shopify-ad-unit-react)
+- [Shopify Ad Unit (Preact)](./shopify-ad-unit-preact)
+
+#### Direct OData integration
+
+Alternatively, you can directly leverage [OData API](./odata-api) requests to get the offer responses that feed our ad units and customize the look and feel yourself. If you go this route, two additional pieces of the integration become your responsibility:
+
+- Fire off **impression events** that let Falcon know when ads are viewed — see the [Impression API](./impression-api) docs.
+- Wrap the ads themselves in the **click URLs** returned on the OData response — see the [Click API](./click-api) docs.

--- a/integration-guide/partner-integration/placements-api.md
+++ b/integration-guide/partner-integration/placements-api.md
@@ -24,6 +24,8 @@ Authorization: Bearer <PUBLISHER_TOKEN>
 
 Creates a new placement (ad unit).
 
+> Default behavior — test mode: Newly created placements default to **test mode** (`isLiveMode: false`). In test mode the OData endpoint returns non-production mock offers — they are **not** real offers from the Falcon network and will not generate revenue or attribution. This is the expected default on the staging environment and for initial UA / test stores you spin up in production while validating an integration. When you create real publishers in production that should serve actual offers, you must explicitly pass `isLiveMode: true` on the create request (or flip the flag later via the Update Placement endpoint).
+
 ### Endpoint
 
 ```
@@ -59,9 +61,9 @@ POST /api/placements
 - `shopifyUrl`: Optional, valid URL or domain
 - `pageType`: Optional, must be valid PageType enum value
   - Valid values: `THANK_YOU_PAGE`, `ORDER_PAGE`
-- `isLiveMode`: Optional, boolean (defaults to false)
-  - `false` (default): Returns non-production mock/test ads for development
-  - `true`: Returns real production offers (use only in production)
+- `isLiveMode`: Optional, boolean (defaults to `false`)
+  - `false` (default): Placement is in **test mode** — OData returns non-production mock/test ads. Expected for staging and for initial UA/test stores in production.
+  - `true`: Placement serves **real offers** from the Falcon network. Required for any real publisher in production that should generate impressions, clicks, and revenue.
 - `template`: Optional, integer between 1 and 21
 - `data`: Optional, custom data object for placement configuration
 

--- a/integration-guide/publisher-integration/overview.md
+++ b/integration-guide/publisher-integration/overview.md
@@ -1,8 +1,8 @@
-# Publisher Integration
+# Custom Publisher Integration
 
 ## Overview
 
-This guide is for **publishers** implementing Falcon's promotional ad unit on their own site or app. It covers the three customer-facing endpoints you'll need to integrate:
+This guide is for **publishers** implementing Falcon's promotional ad unit on their own site or app via direct API integration. It covers the three customer-facing endpoints you'll need to wire up:
 
 1. **[OData API](./odata-api)** — fetch promotional offers to display to a customer.
 2. **[Click API](./click-api)** — record when a customer clicks an offer and redirect them to the advertiser.
@@ -10,13 +10,26 @@ This guide is for **publishers** implementing Falcon's promotional ad unit on th
 
 If you're a platform partner creating publishers, sites, and placements on behalf of merchants, see the [Partner Integration](../partner-integration/overview) guide instead. The Partner guide includes everything here plus management APIs, webhooks, and reporting.
 
+> Prefer the Embedded SDK where you can: If you have full control over the surface the ad renders on, you'll save yourself a lot of work by using our [Embedded Web SDK](/integration-guide/embedded) instead of integrating these endpoints directly. The SDK handles fetching, rendering, impression tracking, and click handling for you. This custom guide is for cases where you need to render offers in your own UI — custom layouts, or environments where the SDK can't run.
+
+## Credentials
+
+To make OData requests you need two things, both of which are provided by your Falcon representative:
+
+- **Public Key** — your publisher-specific bearer token for the OData endpoint. This is the only credential OData uses, and it's safe to ship to the browser.
+- **Placement ID** — identifies the specific ad unit location (e.g., a thank you page) you want to render offers for. You'll typically have one placement ID per surface.
+
+If you don't have either of these yet, reach out to your Falcon rep before starting development.
+
 ## Authentication
 
 The OData API uses the publisher's **Public Key**. The Click and Impression APIs use signed URLs returned by OData, so they don't require separate authentication.
 
 ## Typical flow
 
-1. Call the **OData API** with a placement ID and session/customer data to retrieve one or more offers.
+1. Call the **OData API** with the placement ID and session/customer data to retrieve one or more offers.
 2. Render the offers in your UI.
-3. When an offer is shown to the customer, fire the **Impression API** URL (the `beaconUrl` field on the offer).
+3. When an offer becomes visible to the customer, fire the **Impression API** URL (the `beaconUrl` field on the offer).
 4. When the customer clicks an offer, navigate them to the **Click API** URL (the `clickUrl` field on the offer) — this records the click and redirects to the advertiser.
+
+> Calling OData from a backend? If you proxy OData through your own server rather than calling it directly from the customer's browser, the request's source IP and `User-Agent` will be your server's, not the customer's. Read the original client IP from the `X-Forwarded-For` header (typically the first entry) and the original `User-Agent` from the inbound request, and forward them via the `at.clientIp` and `at.userAgent` parameters. Skipping this disables geo and device targeting and significantly degrades placement performance.


### PR DESCRIPTION
## Summary

- Rewrite the **Partner Integration** overview to frame the integration as two parts (entity hierarchy via Publishers/Sites/Placements APIs, then serving ads) and lay out the three rendering options: Embedded SDK, Shopify React/Preact submodules, and direct OData with manual impression/click wiring.
- Rename **Publisher Integration → Custom Publisher Integration** (page title + sidebar) and expand the overview with an Embedded SDK pointer, a Credentials section explaining the public key + placement ID come from the Falcon rep, and a backend-proxy / `X-Forwarded-For` callout.
- Document **`at.clientIp` and `at.userAgent`** in the shared OData docs as required for production-quality targeting, with a proxy callout explaining how to forward the original client IP and User-Agent.
- Make the **test-mode default** explicit on the Placements API page: newly created placements default to `isLiveMode: false` (mock offers); real production publishers must pass `isLiveMode: true`.
- Rename **Complete Integration Example → Complete Custom Integration Example** and add steps covering OData response handling, firing `beaconUrl` on visibility, and wrapping CTAs in `clickUrl`.
- Add a **Client Context for Targeting** section to Best Practices, refresh the Testing section to point at the Staging Environment page and the test-mode default, and add FAQ entries covering test vs. real offers, backend vs. browser OData calls, and staging vs. production.

## Test plan

- [ ] Run the docs site locally (`npm run docs:dev` or equivalent) and confirm:
  - [ ] Sidebar shows "Custom Publisher Integration" and "Complete Custom Integration Example".
  - [ ] All in-page links resolve (Prerequisites, Staging Environment, Embedded SDK, Shopify React/Preact, OData/Click/Impression APIs, Placements API, Complete Custom Integration Example).
  - [ ] OData page renders the new Required Parameters list and the proxy / `X-Forwarded-For` callout.
  - [ ] Placements API page renders the new test-mode callout above the Create Placement section.
- [ ] Spot-check rendered Markdown for the new bash + JS code blocks in the Complete Custom Integration Example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)