### PR TITLE
docs: add Unified web integration, rename Overlay page

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -23,10 +23,11 @@ export default defineConfig({
         items: [
           {
             text: "Web",
-            link: "/integration-guide/web",
+            link: "/integration-guide/overlay",
             items: [
-              { text: "Overlay", link: "/integration-guide/web" },
+              { text: "Overlay", link: "/integration-guide/overlay" },
               { text: "Embedded", link: "/integration-guide/embedded" },
+              { text: "Unified", link: "/integration-guide/unified" },
             ],
           },
           {

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ hero:
 features:
   - title: Web Integration
     details: Easily integrate the Falcon Perks SDK into your web application.
-    link: /integration-guide/web
+    link: /integration-guide/overlay
   - title: Shopify Integration
     details: Seamlessly integrate Falcon Perks apps into your Shopify store.
     link: /integration-guide/shopify

--- a/integration-guide/overlay.md
+++ b/integration-guide/overlay.md
@@ -8,8 +8,6 @@ The modal can also be minimized to a **floating button** — a small persistent 
 
 Typical use case: show offers on the order confirmation page after a purchase is complete.
 
----
-
 ## Quick Start
 
 Add this to your **order confirmation page** (or any page where you want to show offers). The modal will appear automatically when the page loads:
@@ -49,8 +47,6 @@ Add this to your **order confirmation page** (or any page where you want to show
 That's it. The modal will appear with available offers.
 
 > **Get your credentials:** Contact your Falcon Labs account manager to obtain your SDK key and placement ID.
-
----
 
 ## Framework Examples
 
@@ -214,8 +210,6 @@ import Script from "next/script";
 
 Make sure to add `"use client"` to components that use the SDK.
 
----
-
 ## Custom Attributes
 
 Pass user and order data for personalized offer targeting. The more attributes you provide, the better the targeting.
@@ -287,8 +281,6 @@ interface CustomAttributes {
 }
 ```
 
----
-
 ## Show Options
 
 Customize the modal header when calling `show()`:
@@ -301,8 +293,6 @@ perks.show({
 ```
 
 Both fields are optional.
-
----
 
 ## Callbacks
 
@@ -348,8 +338,6 @@ perks.addUIStateCallback((state) => {
 });
 ```
 
----
-
 ## Error Handling
 
 The SDK throws on invalid operations. Common errors you may encounter:
@@ -362,8 +350,6 @@ The SDK throws on invalid operations. Common errors you may encounter:
 | `Perks already shown`             | `show()` or `loadPerks()` was called while the modal is visible            |
 | `Perks loading`                   | `loadPerks()` was called while a previous load is still in progress        |
 
----
-
 ## Best Practices
 
 1. **Initialize once** — call `FalconSDK.init()` a single time when your page loads, not on every interaction
@@ -371,8 +357,6 @@ The SDK throws on invalid operations. Common errors you may encounter:
 3. **Check `isReady`** — always check `result.isReady` before calling `show()`, as there may not be offers available for this user
 4. **Clean up in SPAs** — call `destroy()` when navigating away from the page to avoid `"Placement already in use"` errors
 5. **One placement = one instance** — don't create multiple instances with the same placement ID
-
----
 
 ## Troubleshooting
 

--- a/integration-guide/unified.md
+++ b/integration-guide/unified.md
@@ -1,0 +1,84 @@
+# Unified Web Integration
+
+## Overview
+
+The Falcon Unified SDK automatically selects the right ad format — **overlay** or **embedded** — for each user based on your Falcon experiment configuration. You write one integration; Falcon handles the routing.
+
+Use this when you want Falcon to dynamically switch or A/B test formats without requiring code changes on your end. If you need a fixed format, use the [Overlay](./overlay) or [Embedded](./embedded) guides instead.
+
+## How It Works
+
+On each `init()` call the SDK:
+
+1. Calls the Falcon experiment API to determine which template is assigned to this user
+2. Creates an overlay or embedded instance accordingly
+3. Falls back to overlay if the experiment call fails for any reason
+
+## Integration
+
+### Step 1: Add the SDK Script
+
+```html
+<script src="https://d6y5cd3imay52.cloudfront.net/sdk/v1/unified-sdk.js"></script>
+```
+
+### Step 2: Add a Container Element
+
+A container is required regardless of which mode Falcon selects — it's the render target for embedded mode and must exist in the DOM before `init()` is called.
+
+```html
+<div id="falcon-ads-container" style="width: 580px; height: 260px;"></div>
+```
+
+Recommended minimum dimensions: **580×260px** desktop, **479×400px** mobile.
+
+### Step 3: Initialize
+
+```javascript
+FalconUnifiedAds.init({
+  apiKey: "YOUR_API_KEY",
+  containerId: "falcon-ads-container",
+  placementId: "YOUR_PLACEMENT_ID",
+});
+```
+
+That's it. The SDK loads and displays offers in whichever format Falcon assigns to this user.
+
+## API Reference
+
+### `FalconUnifiedAds.init(config)`
+
+```typescript
+FalconUnifiedAds.init({
+  apiKey: string;       // Required
+  containerId: string;  // Required — must exist in DOM before calling init()
+  placementId: string;  // Required
+  attributes?: object;  // Optional — see Overlay or Embedded guides for full reference
+});
+```
+
+The method is fire-and-forget (`Promise<void>`). All errors are caught internally and logged to the console — it will never break your page.
+
+**Console prefixes:**
+
+- `[FalconUnifiedAds] Container not found: "{id}"`
+- `[FalconUnifiedAds] Authentication failed`
+- `[FalconUnifiedAds] Connection failed`
+- `[FalconUnifiedAds] Init failed`
+
+## TypeScript
+
+```typescript
+declare const FalconUnifiedAds: {
+  init(config: FalconUnifiedAdsConfig): Promise<void>;
+};
+
+interface FalconUnifiedAdsConfig {
+  apiKey: string;
+  containerId: string;
+  placementId: string;
+  attributes?: FalconUnifiedAdsAttributes;
+}
+```
+
+For the full `FalconUnifiedAdsAttributes` type, see the [Embedded guide](./embedded#typescript).


### PR DESCRIPTION
## Summary

- Add `integration-guide/unified.md` — documents the `FalconUnifiedAds` SDK that auto-routes between overlay and embedded formats via Falcon experiment API
- Rename `web.md` → `overlay.md` for naming consistency with `embedded.md`
- Update sidebar and `index.md` links accordingly

## Test plan

- [ ] Verify sidebar shows Overlay, Embedded, Unified under Web
- [ ] Verify all links resolve correctly (no broken refs to `/integration-guide/web`)
- [ ] Review unified.md for accuracy against `unified-adapter.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)