### PR TITLE
iOS SDK 1.1.0: privacy manifest documentation

### DIFF
--- a/integration-guide/ios/integration.md
+++ b/integration-guide/ios/integration.md
@@ -285,3 +285,32 @@ your attributes dictionary to Falcon placement identifiers. When no mapping is
 provided the raw `view` value is used as the placement id. Keys are looked up
 in order: `"<layout_id>/<view>"` → `"<view>"` → `"<layout_id>"` → raw `view`
 value as fallback.
+
+## Privacy
+
+FalconSDK 1.1.0 and later ships an Apple privacy manifest
+(`PrivacyInfo.xcprivacy`) inside the package. Xcode discovers it automatically
+and includes it in your app's privacy report when you archive — no extra setup
+is required.
+
+**What the manifest declares:**
+
+| Declaration | Value |
+|---|---|
+| Tracking (`NSPrivacyTracking`) | `false`. FalconSDK does not link user data from your app with data from other companies' apps or websites, and does not share data with data brokers. |
+| Collected data | Email address, name, and purchase history — **only if your app passes them** as attributes to `Falcon.execute`. Each is declared as linked to the user's identity, **not** used for tracking, with the purpose "third-party advertising" (displaying promotional offers). |
+| Required-reason APIs | None. The SDK does not use UserDefaults, file timestamps, system uptime, disk space, or keyboard APIs. |
+
+**App Store submission.** In your app's privacy nutrition label, declare email,
+name, and purchase history as shared with Falcon only if your integration
+actually passes those attributes. No App Tracking Transparency (ATT) prompt is
+required for FalconSDK.
+
+## SDK Version
+
+From 1.1.0 the SDK exposes its version as a public constant. Include it in
+support requests and diagnostic logs.
+
+```swift
+print("FalconSDK \(Falcon.version)")  // e.g. "1.1.0"
+```

--- a/integration-guide/ios/integration.md
+++ b/integration-guide/ios/integration.md
@@ -309,9 +309,9 @@ value as fallback.
 ## Privacy
 
 FalconSDK 1.1.0 and later ships an Apple privacy manifest
-(`PrivacyInfo.xcprivacy`) inside the package. Xcode discovers it automatically
-and includes it in your app's privacy report when you archive — no extra setup
-is required.
+(`PrivacyInfo.xcprivacy`) inside the Swift package. Xcode discovers it
+automatically and includes it in your app's privacy report when you archive —
+no extra setup is required.
 
 **What the manifest declares:**
 
@@ -319,6 +319,7 @@ is required.
 |---|---|
 | Tracking (`NSPrivacyTracking`) | `false`. FalconSDK does not link user data from your app with data from other companies' apps or websites, and does not share data with data brokers. |
 | Collected data | Email address, name, and purchase history — **only if your app passes them** as attributes to `Falcon.execute`. Each is declared as linked to the user's identity, **not** used for tracking, with the purpose "third-party advertising" (displaying promotional offers). |
+| Diagnostic data | Other diagnostic data (not linked to the user's identity, not used for tracking, purpose "app functionality") — covers the SDK's PII-free error beacons, see [Diagnostics](#diagnostics). |
 | Required-reason APIs | None. The SDK does not use UserDefaults, file timestamps, system uptime, disk space, or keyboard APIs. |
 
 **App Store submission.** In your app's privacy nutrition label, declare email,
@@ -328,9 +329,9 @@ required for FalconSDK.
 
 ## SDK Version
 
-From 1.1.0 the SDK exposes its version as a public constant. Include it in
-support requests and diagnostic logs.
+The SDK exposes its version as a public constant. Include it in support
+requests and diagnostic logs.
 
 ```swift
-print("FalconSDK \(Falcon.version)")  // e.g. "1.1.0"
+print("FalconSDK \(Falcon.version)")  // e.g. "1.3.1"
 ```


### PR DESCRIPTION
## Summary

Documents the iOS SDK **1.1.0** release on the native SDK integration page (`integration-guide/ios/integration.md`):

- **New "Privacy" section** — FalconSDK 1.1.0+ ships an Apple privacy manifest (`PrivacyInfo.xcprivacy`) inside the package; Xcode picks it up automatically. Documents what it declares (`NSPrivacyTracking = false`; email/name/purchase-history collected only when the host app passes them, linked to identity, not used for tracking, purpose third-party advertising; zero required-reason APIs), nutrition-label guidance for integrators, and that **no ATT prompt is required**.
- **New "SDK Version" section** — the public `Falcon.version` constant (new in 1.1.0) for support/diagnostics.

## Notes

- **Stacked on #56** (`docs/falcon-ios-sdk-v1`): this branch is based on the new-SDK iOS guide rewrite, since the privacy manifest applies to the new FalconSDK package, not the deprecated guide currently on `main`. Please merge #56 first; this PR will then reduce to the single docs commit.
- The site has no SDK version pins, version tables, or changelog (the SPM install snippet uses "Up to Next Major Version"), so no version references needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)