### PR TITLE
iOS SDK 1.2.0: overlay placement documentation

### DIFF
--- a/integration-guide/ios/integration.md
+++ b/integration-guide/ios/integration.md
@@ -124,6 +124,60 @@ Falcon.execute(
 )
 ```
 
+## Add an Overlay Placement
+
+An overlay placement presents the Falcon offer as a **full-screen modal that the
+SDK presents itself** — there is no view to add to your layout and no
+`FalconEmbeddedView` to wire up. Pass `.overlay` as the placement and call
+`Falcon.execute` from any action, such as a button tap. The web content owns
+dismissal: the modal closes when the user closes the offer.
+
+Callbacks (`onLoad`, `onUnload`, `onError`) and per-placement events
+(`.placementInteractive`, `.placementCompleted`, `.placementFailure`) behave
+exactly as they do for an inline placement.
+
+### UIKit
+
+Call `Falcon.execute` from a button action (or any other event handler):
+
+```swift
+@IBAction func showOffer(_ sender: UIButton) {
+    Falcon.execute(
+        attributes: attributes,
+        placement: .overlay,
+        onLoad: {
+            print("overlay loaded")
+        },
+        onUnload: {
+            print("overlay dismissed")
+        },
+        onError: { error in
+            print("overlay error: \(error)")
+        }
+    )
+}
+```
+
+### SwiftUI
+
+Call `Falcon.execute` inside a button action — no wrapper view is required:
+
+```swift
+Button("Show offer") {
+    Falcon.execute(
+        attributes: attributes,
+        placement: .overlay,
+        onLoad: { print("overlay loaded") },
+        onUnload: { print("overlay dismissed") },
+        onError: { error in print("overlay error: \(error)") }
+    )
+}
+```
+
+The SDK locates the frontmost view controller automatically and presents the
+full-screen modal. If no presenter is available, `onError` is called with
+`FalconError.placementLoadError`.
+
 ## Style
 
 Override the visual appearance of a placement by passing a `FalconStyle` value.

--- a/integration-guide/ios/integration.md
+++ b/integration-guide/ios/integration.md
@@ -129,8 +129,11 @@ Falcon.execute(
 An overlay placement presents the Falcon offer as a **full-screen modal that the
 SDK presents itself** — there is no view to add to your layout and no
 `FalconEmbeddedView` to wire up. Pass `.overlay` as the placement and call
-`Falcon.execute` from any action, such as a button tap. The web content owns
-dismissal: the modal closes when the user closes the offer.
+`Falcon.execute` from any action, such as a button tap. The modal closes when
+the user closes the offer (the web content owns dismissal). From SDK 1.3.1 the
+overlay also dismisses itself automatically if the placement fails to load or
+produces no content within 15 seconds, so a broken placement can never leave
+the user stuck on a full-screen modal; `onError` fires in that case.
 
 Callbacks (`onLoad`, `onUnload`, `onError`) and per-placement events
 (`.placementInteractive`, `.placementCompleted`, `.placementFailure`) behave


### PR DESCRIPTION
## Summary

Documents the new `FalconPlacement.overlay` placement shipping in **iOS SDK 1.2.0** on the iOS integration guide (`integration-guide/ios/integration.md`).

A new **Add an Overlay Placement** section (inserted after *Sandbox Mode*, before *Style*) covers:
- What it is: a full-screen modal that the **SDK presents itself** — no host view / `FalconEmbeddedView` needed (unlike the inline placement).
- Dismissal: the web content closes the modal via its own close button; since SDK 1.3.1 a load failure or 15-second load timeout also dismisses it automatically.
- `Falcon.execute(placement: .overlay)` usage for both **UIKit** (from a button action) and **SwiftUI** (inside a button action, no wrapper view).
- Callbacks (`onLoad`/`onUnload`/`onError`) and events (`.placementInteractive`/`.placementCompleted`/`.placementFailure`) behave identically to the inline placement.
- If no presenter is available, `onError` is called with `FalconError.placementLoadError`.

The `.overlay` usage keeps the same shape as the equivalent placement in other ad SDKs, so migrating apps keep their existing call sites.

## Validation
- `npm run docs:build` (VitePress) completes successfully. The only warning (`proguard` language fallback) is pre-existing and unrelated (Android page).

## Changelog
No changelog / version-reference page exists in this docs site, so no version entry was added (same finding as the 1.1.0 docs work).

## Stack dependency
This PR was stacked on `ios-sdk-1.1.0-privacy` (PR #58), which contained the new-SDK integration-guide rewrite (PR #56). Both have merged; this PR is now retargeted to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
