### PR TITLE
iOS SDK 1.3.0: diagnostics documentation

### DIFF
--- a/integration-guide/ios/integration.md
+++ b/integration-guide/ios/integration.md
@@ -346,6 +346,8 @@ Your account manager will provide the values specific to your integration.
 |---|---|---|---|
 | `baseURL` | `URL` | `https://pr.falconlabs.us` | Base URL of the Falcon web frontend. Keep the default unless your account manager tells you otherwise. |
 | `placementMapping` | `[String: String]` | `[:]` | Maps the `layout_id` / `view` values in your attributes dictionary to Falcon placement identifiers. |
+| `diagnosticBeaconsEnabled` | `Bool` | `true` | When `true`, the SDK POSTs PII-free error beacons on placement failure (see [Diagnostics](#diagnostics)). |
+| `diagnosticsURL` | `URL?` | `nil` | Overrides the beacon endpoint. When `nil`, beacons go to the Falcon backend. |
 
 ```swift
 let config = FalconConfig(
@@ -423,6 +425,8 @@ Falcon.diagnosticsDelegate = MyDiagnosticsHandler()
 | `urlConstructionFailed` | the webview URL could not be built |
 | `webviewNavigationFailed` | `WKWebView` navigation error |
 | `webviewProvisionalNavigationFailed` | `WKWebView` provisional navigation error |
+| `webviewHTTPError` | the main-frame response had an HTTP status of 400 or higher; the placement fails (1.3.1+) |
+| `webviewLoadTimedOut` | the placement produced no signal within 15 seconds of starting the load; the placement fails and an overlay dismisses itself (1.3.1+) |
 | `bridgeReportedError` | the JS bridge posted an `error` event |
 | `noPresenter` | an overlay found no frontmost view controller |
 
@@ -442,7 +446,13 @@ Falcon.initSdk(
 A beacon contains **no user data** — no user attributes, email, API key, or
 free-form message text. It carries only:
 `{ sdkv, code, placement, layoutId, platform, ts }`. Beacons are
-fire-and-forget and silently drop on network failure.
+fire-and-forget and silently drop on network failure. They are only sent after
+`Falcon.initSdk` has been called — the `initNotCalled` diagnostic never reaches
+the network (it surfaces through the delegate and the system log only).
+
+If you route SDK telemetry through your own infrastructure, override the beacon
+endpoint with `FalconConfig(diagnosticsURL:)`; when unset, beacons go to the
+Falcon backend.
 
 > **Important:** the `placement` and `layoutId` fields come from your
 > `placement_details.view` and `placement_details.layout_id`. Because they are

--- a/integration-guide/ios/integration.md
+++ b/integration-guide/ios/integration.md
@@ -360,6 +360,78 @@ name, and purchase history as shared with Falcon only if your integration
 actually passes those attributes. No App Tracking Transparency (ATT) prompt is
 required for FalconSDK.
 
+## Diagnostics
+
+FalconSDK 1.3.0 and later adds observability so you (and Falcon Labs) can see
+**why** a placement failed instead of only a generic error. It works through
+three channels. This is purely additive — the existing `onError` callback and
+`FalconError` cases are unchanged.
+
+### Host delegate (opt-in)
+
+Set `Falcon.diagnosticsDelegate` once at launch to receive a `FalconDiagnostic`
+for every SDK failure. Route it into Sentry, Datadog, or your own logging. The
+delegate is unset by default, and setting it changes nothing else about the
+SDK's behavior.
+
+```swift
+import FalconSDK
+
+class MyDiagnosticsHandler: FalconDiagnosticsDelegate {
+    func falconDidEncounter(_ diagnostic: FalconDiagnostic) {
+        // diagnostic.code     — FalconDiagnosticCode (granular reason)
+        // diagnostic.message  — human-readable description (local only)
+        // diagnostic.placement, diagnostic.layoutId — routing context
+        MyErrorTracker.capture(diagnostic.code.rawValue)
+    }
+}
+
+// In your AppDelegate or app init:
+Falcon.diagnosticsDelegate = MyDiagnosticsHandler()
+```
+
+`FalconDiagnosticCode` cases:
+
+| Code | When |
+|---|---|
+| `initNotCalled` | `execute` called before `initSdk` |
+| `attributeMappingFailed` | attributes did not resolve to a placement |
+| `urlConstructionFailed` | the webview URL could not be built |
+| `webviewNavigationFailed` | `WKWebView` navigation error |
+| `webviewProvisionalNavigationFailed` | `WKWebView` provisional navigation error |
+| `bridgeReportedError` | the JS bridge posted an `error` event |
+| `noPresenter` | an overlay found no frontmost view controller |
+
+### Error beacons
+
+On failure the SDK also POSTs a small, PII-free diagnostic to Falcon Labs so we
+can spot integration issues proactively. Beacons are **on by default**. To
+disable them (e.g. for privacy-sensitive environments):
+
+```swift
+Falcon.initSdk(
+    apiKey: "YOUR_API_KEY",
+    config: FalconConfig(diagnosticBeaconsEnabled: false)
+)
+```
+
+A beacon contains **no user data** — no user attributes, email, API key, or
+free-form message text. It carries only:
+`{ sdkv, code, placement, layoutId, platform, ts }`. Beacons are
+fire-and-forget and silently drop on network failure.
+
+> **Important:** the `placement` and `layoutId` fields come from your
+> `placement_details.view` and `placement_details.layout_id`. Because they are
+> sent in diagnostics, **do not put user data in `view` or `layout_id`**. (Each
+> is capped at 128 characters.)
+
+### System log
+
+Diagnostics are also written to the Apple unified log under subsystem
+`us.falconlabs.FalconSDK` (category `diagnostics`). In **Console.app**, filter
+by that subsystem to see them. The diagnostic `code` is logged publicly; the
+human-readable `message` stays on-device.
+
 ## SDK Version
 
 From 1.1.0 the SDK exposes its version as a public constant. Include it in


### PR DESCRIPTION
## Summary

Adds a **Diagnostics** section to the iOS SDK integration guide (`integration-guide/ios/integration.md`) documenting the new observability feature shipping in FalconSDK **1.3.0**. The change is purely additive to the page — the existing `onError` / `FalconError` docs are unchanged.

The new section covers all three diagnostic channels:

- **`FalconDiagnosticsDelegate`** (opt-in) — set `Falcon.diagnosticsDelegate` once to receive a `FalconDiagnostic` for every SDK failure and route it into Sentry/Datadog/your own logging. Includes a short Swift example and the full `FalconDiagnosticCode` table.
- **PII-free error beacons** (on by default) — automatic POST of `{ sdkv, code, placement, layoutId, platform, ts }` to Falcon Labs on failure, with the `FalconConfig(diagnosticBeaconsEnabled: false)` opt-out and the **"do not put user data in `view`/`layout_id`"** note (those fields are sent in diagnostics; capped at 128 chars).
- **System log** — diagnostics also go to the Apple unified log under subsystem `us.falconlabs.FalconSDK` (filter in Console.app).

Placed after **Privacy** and before **SDK Version**, matching the page's voice and conventions. Adapted from the SDK README into client-facing docs (no internal repo paths). No changelog/version reference file exists in this repo, so none was added (consistent with the prior iOS PRs).

`npm run docs:build` passes (the `proguard` highlight warning is pre-existing, from the Android page).

## Stack dependency

This PR is **stacked on #59** (`ios-sdk-1.2.0-overlay`), which is itself stacked on #58 (privacy) and #56 (base iOS integration guide). Merge those first / retarget to `main` once the stack lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)