### PR TITLE
docs: add Disney+/Hulu bundle terms page

### DIFF
--- a/terms/disney.md
+++ b/terms/disney.md
@@ -1,0 +1,8 @@
+---
+layout: blank-page
+title: Terms and Conditions
+---
+
+## Terms and Conditions
+
+Savings compared to reg monthly price of Disney+, Hulu Bundle (With Ads). Offer available for ad-supported Disney+, Hulu Bundle (With Ads) plan. Offer valid until 11:59 PM PST on 12/31/26. U.S. only. 18+. Valid only for new and returning subscribers with no current active entitlement to any Disney+, Hulu, and/or ESPN+ plan. After 3 months, Disney+, Hulu Bundle (With Ads) automatically renews at then-current monthly price (currently $12.99/mo) (plus tax, where applicable) unless you cancel before then. Cancel anytime, subject to terms. Cannot be transferred or combined with other offers, coupons, discounts or promotions. Terms apply.


### PR DESCRIPTION
Adds a new terms & conditions page at `terms/disney.md`, published at `/terms/disney`.

Contains the Disney+, Hulu Bundle (With Ads) promotional offer terms. Like the other `terms/*` pages, it uses the `blank-page` layout and is reachable by URL but not linked in the site sidebar/nav.

Linear: [FAL-2495](https://linear.app/falcon-labs/issue/FAL-2495/add-disneyhulu-bundle-terms-page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)