### PR TITLE
Add Sveltia CMS for non-dev content editing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,12 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Fired by the Sveltia CMS "Publish Changes" button. CMS edits commit with a
+  # [skip ci] prefix (backend.skip_ci in public/admin/config.yml), so pushes do
+  # NOT deploy; an editor clicks "Publish Changes" to trigger this event instead.
+  repository_dispatch:
+    types: [sveltia-cms-publish]
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/getting-started/entities.md
+++ b/getting-started/entities.md
@@ -1,3 +1,7 @@
+---
+title: "Core concepts"
+---
+
 # Core concepts
 
 In order to best use Falcon, it is recommended to first understand the core data

--- a/getting-started/overview.md
+++ b/getting-started/overview.md
@@ -1,3 +1,7 @@
+---
+title: "Falcon Perks Overview"
+---
+
 # Falcon Perks Overview
 
 The Falcon Perks Platform gives you a plug-and-play solution to deliver perks to your customers and critical moments in the purchase journey.

--- a/integration-guide/crud-api-placement.md
+++ b/integration-guide/crud-api-placement.md
@@ -1,3 +1,7 @@
+---
+title: "Placement API Documentation"
+---
+
 # Placement API Documentation
 
 **Base URL**: `/api/placements`

--- a/integration-guide/crud-api-publisher.md
+++ b/integration-guide/crud-api-publisher.md
@@ -1,3 +1,7 @@
+---
+title: "Publisher API Documentation"
+---
+
 # Publisher API Documentation
 
 **Base URL**: `/api/v1/publishers`

--- a/integration-guide/crud-api-site.md
+++ b/integration-guide/crud-api-site.md
@@ -1,3 +1,7 @@
+---
+title: "Site API Documentation"
+---
+
 # Site API Documentation
 
 **Base URL**: `/api/site`

--- a/integration-guide/embedded-sdk-callbacks.md
+++ b/integration-guide/embedded-sdk-callbacks.md
@@ -1,1 +1,5 @@
+---
+title: "Embedded SDK Callbacks"
+---
+
 <!--@include: ./_shared/embedded-sdk-callbacks.md-->

--- a/integration-guide/embedded.md
+++ b/integration-guide/embedded.md
@@ -1,3 +1,7 @@
+---
+title: "Embedded Web Integration"
+---
+
 # Embedded Web Integration
 
 ## Overview

--- a/integration-guide/falcon.md
+++ b/integration-guide/falcon.md
@@ -1,3 +1,7 @@
+---
+title: "Falcon web2app"
+---
+
 # Falcon web2app
 
 ## Overview

--- a/integration-guide/mobile/android.md
+++ b/integration-guide/mobile/android.md
@@ -1,3 +1,7 @@
+---
+title: "Android Integration"
+---
+
 # Android Integration
 
 Display Falcon Perks in your Android app using `WebView`. No native SDK download required.

--- a/integration-guide/mobile/ios.md
+++ b/integration-guide/mobile/ios.md
@@ -1,3 +1,7 @@
+---
+title: "iOS Integration"
+---
+
 # iOS Integration
 
 Display Falcon Perks in your iOS app using `WKWebView`. No native SDK download required.

--- a/integration-guide/mobile/overview.md
+++ b/integration-guide/mobile/overview.md
@@ -1,3 +1,7 @@
+---
+title: "Mobile Integration"
+---
+
 # Mobile Integration
 
 Falcon Perks can be displayed in native iOS and Android apps using a **WebView**. Your app loads a Falcon-hosted page inside a WebView, and communication between the WebView and your native code happens through a JavaScript bridge.

--- a/integration-guide/overlay.md
+++ b/integration-guide/overlay.md
@@ -1,3 +1,7 @@
+---
+title: "Overlay Web Integration"
+---
+
 # Overlay Web Integration
 
 ## Overview

--- a/integration-guide/overview.md
+++ b/integration-guide/overview.md
@@ -1,3 +1,7 @@
+---
+title: "Integration Overview"
+---
+
 # Integration Overview
 Below are guides that will help you integrate the Falcon Perks SDK into your application.
 

--- a/integration-guide/partner-integration/advanced/embedded-sdk-callbacks.md
+++ b/integration-guide/partner-integration/advanced/embedded-sdk-callbacks.md
@@ -1,1 +1,5 @@
+---
+title: "Embedded SDK Callbacks"
+---
+
 <!--@include: ../../_shared/embedded-sdk-callbacks.md-->

--- a/integration-guide/partner-integration/authentication-and-platform-tokens.md
+++ b/integration-guide/partner-integration/authentication-and-platform-tokens.md
@@ -1,3 +1,7 @@
+---
+title: "Authentication and Platform Tokens"
+---
+
 ## Authentication & Platform Tokens
 
 ### Platform Token Overview

--- a/integration-guide/partner-integration/best-practices.md
+++ b/integration-guide/partner-integration/best-practices.md
@@ -1,3 +1,7 @@
+---
+title: "Best Practices"
+---
+
 ## Best Practices
 
 ### 1. Secure Key Storage

--- a/integration-guide/partner-integration/click-api.md
+++ b/integration-guide/partner-integration/click-api.md
@@ -1,1 +1,5 @@
+---
+title: "Click API"
+---
+
 <!--@include: ../_shared/click-api.md-->

--- a/integration-guide/partner-integration/complete-integration-example.md
+++ b/integration-guide/partner-integration/complete-integration-example.md
@@ -1,3 +1,7 @@
+---
+title: "Complete Integration Example"
+---
+
 ## Complete Custom Integration Example
 
 This is a complete walkthrough of the **custom integration path** — creating the entity hierarchy as a partner, then rendering offers yourself by calling OData directly and wiring up the click and impression URLs returned in the response. If you have full control over the surface and don't need to customize rendering, prefer the [Embedded Web SDK](/integration-guide/embedded) — it handles fetching, rendering, impression tracking, and click handling for you. This guide is for cases where you're rendering offers in your own UI.

--- a/integration-guide/partner-integration/error-handling-reference.md
+++ b/integration-guide/partner-integration/error-handling-reference.md
@@ -1,3 +1,7 @@
+---
+title: "Error Handling Reference"
+---
+
 ## Error Handling Reference
 
 ### **Error Response Format**

--- a/integration-guide/partner-integration/frequently-asked-questions.md
+++ b/integration-guide/partner-integration/frequently-asked-questions.md
@@ -1,3 +1,7 @@
+---
+title: "Frequently Asked Questions"
+---
+
 ## Frequently Asked Questions
 
 ### Q: What’s the difference between public and private keys?

--- a/integration-guide/partner-integration/impression-api.md
+++ b/integration-guide/partner-integration/impression-api.md
@@ -1,1 +1,5 @@
+---
+title: "Impression API"
+---
+
 <!--@include: ../_shared/impression-api.md-->

--- a/integration-guide/partner-integration/lifecycle-webhooks.md
+++ b/integration-guide/partner-integration/lifecycle-webhooks.md
@@ -1,3 +1,7 @@
+---
+title: "Lifecycle Webhooks"
+---
+
 ## Lifecycle Webhooks
 
 ### Overview

--- a/integration-guide/partner-integration/odata-api.md
+++ b/integration-guide/partner-integration/odata-api.md
@@ -1,1 +1,5 @@
+---
+title: "OData API"
+---
+
 <!--@include: ../_shared/odata-api.md-->

--- a/integration-guide/partner-integration/overview.md
+++ b/integration-guide/partner-integration/overview.md
@@ -1,3 +1,7 @@
+---
+title: "Falcon Partner Integration Guide"
+---
+
 # Falcon Partner Integration Guide
 
 ## Overview

--- a/integration-guide/partner-integration/placements-api.md
+++ b/integration-guide/partner-integration/placements-api.md
@@ -1,3 +1,7 @@
+---
+title: "Placements API"
+---
+
 ## Placements API
 
 ### Overview

--- a/integration-guide/partner-integration/prerequisites.md
+++ b/integration-guide/partner-integration/prerequisites.md
@@ -1,3 +1,7 @@
+---
+title: "Prerequisites"
+---
+
 ## Prerequisites
 
 ### Required Credentials

--- a/integration-guide/partner-integration/publishers-api.md
+++ b/integration-guide/partner-integration/publishers-api.md
@@ -1,3 +1,7 @@
+---
+title: "Publishers API"
+---
+
 ## Publishers API
 
 ### Overview

--- a/integration-guide/partner-integration/rate-limits.md
+++ b/integration-guide/partner-integration/rate-limits.md
@@ -1,3 +1,7 @@
+---
+title: "Rate Limits"
+---
+
 ## Rate Limits
 
 ### API Rate Limiting Policy

--- a/integration-guide/partner-integration/reporting-api.md
+++ b/integration-guide/partner-integration/reporting-api.md
@@ -1,1 +1,5 @@
+---
+title: "Reporting API"
+---
+
 <!--@include: ../_shared/reporting-api.md-->

--- a/integration-guide/partner-integration/shopify-ad-unit-preact.md
+++ b/integration-guide/partner-integration/shopify-ad-unit-preact.md
@@ -1,3 +1,7 @@
+---
+title: "Shopify Ad Unit (Preact)"
+---
+
 # Shopify Ad Unit (Preact)
 
 ## Overview

--- a/integration-guide/partner-integration/shopify-ad-unit-react.md
+++ b/integration-guide/partner-integration/shopify-ad-unit-react.md
@@ -1,3 +1,7 @@
+---
+title: "Shopify Ad Unit (React)"
+---
+
 # Shopify Ad Unit (React)
 
 ## Overview

--- a/integration-guide/partner-integration/sites-api.md
+++ b/integration-guide/partner-integration/sites-api.md
@@ -1,3 +1,7 @@
+---
+title: "Sites API"
+---
+
 ## Sites API
 
 ### Overview

--- a/integration-guide/partner-integration/staging-environment.md
+++ b/integration-guide/partner-integration/staging-environment.md
@@ -1,3 +1,7 @@
+---
+title: "Staging Environment"
+---
+
 ## Staging Environment
 
 ### Environment URLs

--- a/integration-guide/publisher-integration/click-api.md
+++ b/integration-guide/publisher-integration/click-api.md
@@ -1,1 +1,5 @@
+---
+title: "Click API"
+---
+
 <!--@include: ../_shared/click-api.md-->

--- a/integration-guide/publisher-integration/impression-api.md
+++ b/integration-guide/publisher-integration/impression-api.md
@@ -1,1 +1,5 @@
+---
+title: "Impression API"
+---
+
 <!--@include: ../_shared/impression-api.md-->

--- a/integration-guide/publisher-integration/odata-api.md
+++ b/integration-guide/publisher-integration/odata-api.md
@@ -1,1 +1,5 @@
+---
+title: "OData API"
+---
+
 <!--@include: ../_shared/odata-api.md-->

--- a/integration-guide/publisher-integration/overview.md
+++ b/integration-guide/publisher-integration/overview.md
@@ -1,3 +1,7 @@
+---
+title: "Custom Publisher Integration"
+---
+
 # Custom Publisher Integration
 
 ## Overview

--- a/integration-guide/reporting-api.md
+++ b/integration-guide/reporting-api.md
@@ -1,3 +1,7 @@
+---
+title: "Reporting API Guide"
+---
+
 # Reporting API Guide
 
 This guide covers Falcon's Reporting API — the endpoint for pulling placement and site performance metrics (requests, clicks, conversions, revenue, CTR, and more).

--- a/integration-guide/shopify.md
+++ b/integration-guide/shopify.md
@@ -1,3 +1,7 @@
+---
+title: "Shopify Integration docs"
+---
+
 # Shopify Integration docs
 
 ## Installing Falcon Shopify Widget

--- a/integration-guide/shopify/shopify-step-by-step.md
+++ b/integration-guide/shopify/shopify-step-by-step.md
@@ -1,3 +1,7 @@
+---
+title: "How to get started with Falcon on Shopify?"
+---
+
 # How to get started with Falcon on Shopify?
 
 Getting started with Falcon is super easy, and should take less than 10 minutes 🚀

--- a/integration-guide/unified.md
+++ b/integration-guide/unified.md
@@ -1,3 +1,7 @@
+---
+title: "Unified Web Integration"
+---
+
 # Unified Web Integration
 
 ## Overview

--- a/integration-guide/wix.md
+++ b/integration-guide/wix.md
@@ -1,3 +1,7 @@
+---
+title: "Installing Falcon Wix App"
+---
+
 # Installing Falcon Wix App
 
 Boost your Wix store by adding our advertising widget in just a few simple steps.

--- a/public/admin/README.md
+++ b/public/admin/README.md
@@ -1,0 +1,41 @@
+# Sveltia CMS
+
+A Git-backed CMS that lets non-developers edit this docs site without touching Git.
+Editors go to **https://docs.falconlabs.us/admin/**, sign in with GitHub, and edit
+content through a form UI. Saving commits Markdown straight to `main`, which triggers
+the normal GitHub Pages deploy (`.github/workflows/deploy.yml`).
+
+## Files
+
+- `index.html` — loads Sveltia CMS from the CDN (pinned to a version).
+- `config.yml` — backend + collections. Committing straight to `main` (no PR flow).
+
+## Auth architecture
+
+Login uses a GitHub OAuth proxy — a Cloudflare Worker (`falcon-cms-auth`) that lives in
+the `falcon-protocol/promo-ad-unit` repo under `cloudflare-worker/cms-auth/` and is
+deployed by that repo's CI. GitHub only ever talks to the worker; the token is handed
+back to this site's `/admin/` page via `postMessage`.
+
+- Worker origin (`base_url` in `config.yml`): `https://cms-auth.falconlabs.us`
+- OAuth App callback URL: `https://cms-auth.falconlabs.us/callback`
+
+## One-time setup checklist
+
+These live OUTSIDE this repo and must be done once before login works:
+
+1. **Register a GitHub OAuth App** (org: `falcon-protocol`)
+   - Homepage URL: `https://docs.falconlabs.us`
+   - Authorization callback URL: `https://cms-auth.falconlabs.us/callback`
+2. **Set the worker secrets** (in the `promo-ad-unit` repo, `cloudflare-worker/cms-auth/`):
+   - `npx wrangler secret put GITHUB_CLIENT_ID --env production`
+   - `npx wrangler secret put GITHUB_CLIENT_SECRET --env production`
+3. **Give each editor write access** to `falcon-protocol/docs-ecommerce`.
+
+## Notes
+
+- The site is served via GitHub Pages, which cannot set custom response headers. This is
+  fine: OAuth popups need a permissive `Cross-Origin-Opener-Policy`, and Pages sends none
+  (default `unsafe-none`), so the popup → opener handoff works. Only a *strict* `same-origin`
+  COOP would break it — don't add one.
+- New CMS image uploads go to `public/uploads/`. Existing `/images/` are untouched.

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -2,6 +2,11 @@ backend:
   name: github
   repo: falcon-protocol/docs-ecommerce
   branch: main
+  # Manual publishing: saves commit with a [skip ci] prefix (no auto-deploy).
+  # Editors click "Publish Changes" in the CMS header, which fires a
+  # repository_dispatch (sveltia-cms-publish) that .github/workflows/deploy.yml
+  # listens for. Lets edits accumulate and go live only on an explicit publish.
+  skip_ci: true
   # Cloudflare Worker OAuth proxy (deployed from promo-ad-unit#1040).
   # Worker: falcon-cms-auth, route cms-auth.falconlabs.us/*.
   # GitHub OAuth App callback must be https://cms-auth.falconlabs.us/callback.
@@ -49,14 +54,19 @@ collections:
               - { label: Link, name: link, widget: string }
           - { label: Body (below frontmatter), name: body, widget: markdown, required: false }
 
-      - { name: merchant, label: Merchants, file: merchant.md, fields: [{ label: Body, name: body, widget: markdown }] }
-      - { name: publisher, label: Publishers, file: publisher.md, fields: [{ label: Body, name: body, widget: markdown }] }
-      - { name: soft, label: Soft bundles, file: soft.md, fields: [{ label: Body, name: body, widget: markdown }] }
-      - { name: bundle-modes, label: Bundle modes, file: bundle-modes.md, fields: [{ label: Body, name: body, widget: markdown }] }
-      - { name: bundle-types, label: Bundle types, file: bundle-types.md, fields: [{ label: Body, name: body, widget: markdown }] }
-      - { name: api-examples, label: API examples, file: api-examples.md, fields: [{ label: Body, name: body, widget: markdown }] }
+      # These body-only pages use raw Markdown editing (modes: [raw]) so Sveltia
+      # stores the body verbatim — the visual editor re-serializes on save and
+      # would mangle any custom syntax (see soft.md / api-examples.md).
+      - { name: merchant, label: Merchants, file: merchant.md, fields: [{ label: Body, name: body, widget: markdown, modes: [raw] }] }
+      - { name: publisher, label: Publishers, file: publisher.md, fields: [{ label: Body, name: body, widget: markdown, modes: [raw] }] }
+      - { name: soft, label: Soft bundles, file: soft.md, fields: [{ label: Body, name: body, widget: markdown, modes: [raw] }] }
+      - { name: bundle-modes, label: Bundle modes, file: bundle-modes.md, fields: [{ label: Body, name: body, widget: markdown, modes: [raw] }] }
+      - { name: bundle-types, label: Bundle types, file: bundle-types.md, fields: [{ label: Body, name: body, widget: markdown, modes: [raw] }] }
+      - { name: api-examples, label: API examples, file: api-examples.md, fields: [{ label: Body, name: body, widget: markdown, modes: [raw] }] }
 
   # ─── Getting Started ─────────────────────────────────────────────────────────
+  # Raw Markdown editing: these pages use ::: containers; the visual editor would
+  # mangle them, so modes: [raw] keeps the body verbatim.
   - name: getting-started
     label: Getting Started
     label_singular: Getting Started page
@@ -67,18 +77,19 @@ collections:
     format: frontmatter
     fields:
       - { label: Title, name: title, widget: string, required: false }
-      - { label: Description, name: description, widget: string, required: false }
-      - { label: Body, name: body, widget: markdown }
+      - { label: Description, name: description, widget: string, required: false, hint: "Shown in Google results and link/social previews — not on the page itself. ~150 characters." }
+      - { label: Body, name: body, widget: markdown, modes: [raw] }
 
-  # ─── Integration Guide (nested, preserves subdirectory structure) ───────────
+  # ─── Integration Guide (nested; preserves subdirectory structure) ────────────
+  # Raw Markdown editing: these pages use ::: containers, raw HTML, JSX and
+  # <!--@include--> snippets. modes: [raw] preserves all of it verbatim on save.
+  # _shared/ snippets are included via <!--@include--> and are left out of nav,
+  # but remain editable here as raw Markdown.
   - name: integration-guide
     label: Integration Guide
     label_singular: Integration guide page
     folder: integration-guide
     create: true
-    # Allow editors to create/edit files anywhere in integration-guide/,
-    # including partner-integration/, mobile/, shopify/, publisher-integration/,
-    # ios/, and _shared/ (used for reusable snippets).
     nested:
       depth: 4
       summary: '{{title}}'
@@ -87,15 +98,19 @@ collections:
     format: frontmatter
     fields:
       - { label: Title, name: title, widget: string, required: false }
-      - { label: Description, name: description, widget: string, required: false }
-      - { label: Body, name: body, widget: markdown }
+      - { label: Description, name: description, widget: string, required: false, hint: "Shown in Google results and link/social previews — not on the page itself. ~150 characters." }
+      - { label: Body, name: body, widget: markdown, modes: [raw] }
 
   # ─── Terms & Legal ───────────────────────────────────────────────────────────
+  # Plain prose edited by non-devs → keep the friendly visual (WYSIWYG) editor.
   - name: terms
     label: Terms & Legal
     label_singular: Terms page
     folder: terms
     create: true
+    # Many terms pages share the same title ("Terms and Conditions"), so label
+    # entries in the list by filename (disney, audiobooks, …) to disambiguate.
+    summary: '{{filename}}'
     slug: '{{slug}}'
     extension: md
     format: frontmatter

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,0 +1,105 @@
+backend:
+  name: github
+  repo: falcon-protocol/docs-ecommerce
+  branch: main
+  # Cloudflare Worker OAuth proxy (deployed from promo-ad-unit#1040).
+  # Worker: falcon-cms-auth, route cms-auth.falconlabs.us/*.
+  # GitHub OAuth App callback must be https://cms-auth.falconlabs.us/callback.
+  base_url: https://cms-auth.falconlabs.us
+
+# Media uploaded via the CMS lands in /public/uploads/ and is served at /uploads/.
+# Existing images under /images/ (referenced from markdown as ./images/foo.png) are
+# untouched — this only governs new uploads made through the CMS.
+media_folder: public/uploads
+public_folder: /uploads
+
+site_url: https://docs.falconlabs.us
+
+collections:
+  # ─── Root-level overview pages ───────────────────────────────────────────────
+  - name: overview
+    label: Overview Pages
+    label_singular: Overview page
+    files:
+      - name: home
+        label: Home page (index.md)
+        file: index.md
+        fields:
+          - { name: layout, widget: hidden, default: home }
+          - name: hero
+            label: Hero
+            widget: object
+            fields:
+              - { label: Name, name: name, widget: string }
+              - { label: Text, name: text, widget: string }
+              - { label: Tagline, name: tagline, widget: string }
+              - name: actions
+                label: Call-to-action buttons
+                widget: list
+                fields:
+                  - { label: Theme, name: theme, widget: string, default: brand }
+                  - { label: Button text, name: text, widget: string }
+                  - { label: Link, name: link, widget: string }
+          - name: features
+            label: Features
+            widget: list
+            fields:
+              - { label: Title, name: title, widget: string }
+              - { label: Details, name: details, widget: string }
+              - { label: Link, name: link, widget: string }
+          - { label: Body (below frontmatter), name: body, widget: markdown, required: false }
+
+      - { name: merchant, label: Merchants, file: merchant.md, fields: [{ label: Body, name: body, widget: markdown }] }
+      - { name: publisher, label: Publishers, file: publisher.md, fields: [{ label: Body, name: body, widget: markdown }] }
+      - { name: soft, label: Soft bundles, file: soft.md, fields: [{ label: Body, name: body, widget: markdown }] }
+      - { name: bundle-modes, label: Bundle modes, file: bundle-modes.md, fields: [{ label: Body, name: body, widget: markdown }] }
+      - { name: bundle-types, label: Bundle types, file: bundle-types.md, fields: [{ label: Body, name: body, widget: markdown }] }
+      - { name: api-examples, label: API examples, file: api-examples.md, fields: [{ label: Body, name: body, widget: markdown }] }
+
+  # ─── Getting Started ─────────────────────────────────────────────────────────
+  - name: getting-started
+    label: Getting Started
+    label_singular: Getting Started page
+    folder: getting-started
+    create: true
+    slug: '{{slug}}'
+    extension: md
+    format: frontmatter
+    fields:
+      - { label: Title, name: title, widget: string, required: false }
+      - { label: Description, name: description, widget: string, required: false }
+      - { label: Body, name: body, widget: markdown }
+
+  # ─── Integration Guide (nested, preserves subdirectory structure) ───────────
+  - name: integration-guide
+    label: Integration Guide
+    label_singular: Integration guide page
+    folder: integration-guide
+    create: true
+    # Allow editors to create/edit files anywhere in integration-guide/,
+    # including partner-integration/, mobile/, shopify/, publisher-integration/,
+    # ios/, and _shared/ (used for reusable snippets).
+    nested:
+      depth: 4
+      summary: '{{title}}'
+    path: '{{slug}}'
+    extension: md
+    format: frontmatter
+    fields:
+      - { label: Title, name: title, widget: string, required: false }
+      - { label: Description, name: description, widget: string, required: false }
+      - { label: Body, name: body, widget: markdown }
+
+  # ─── Terms & Legal ───────────────────────────────────────────────────────────
+  - name: terms
+    label: Terms & Legal
+    label_singular: Terms page
+    folder: terms
+    create: true
+    slug: '{{slug}}'
+    extension: md
+    format: frontmatter
+    fields:
+      - { label: Layout, name: layout, widget: string, required: false, default: blank-page, hint: "Use 'blank-page' for standalone terms pages." }
+      - { label: Title, name: title, widget: string, required: false }
+      - { label: Body, name: body, widget: markdown }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Content Manager</title>
+  </head>
+  <body>
+    <script src="https://unpkg.com/@sveltia/cms@0.120.1/dist/sveltia-cms.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Adds **Sveltia CMS** at `/admin/` so non-developers can create and edit docs pages through a form UI — no Git required. Saves commit Markdown to the repo; the existing GitHub Pages workflow publishes it. Motivated by the recurring need for someone to post/update a terms page (e.g. Disney) without a dev.

Pairs with the OAuth proxy worker deployed in `promo-ad-unit#1040` (`cms-auth.falconlabs.us`).

## What's included

- **`public/admin/`** — Sveltia loader (`index.html`, pinned), `config.yml`, and a `README.md` documenting the auth architecture + one-time setup.
- **Collections:** `overview` (home + concept pages), `getting-started`, `integration-guide` (nested), and `terms` (create-enabled — the primary non-dev use case).
- **Lossless editing of technical docs:** pages with custom VitePress syntax (`:::` containers, raw HTML, `<!--@include-->`) use the markdown field's `modes: [raw]`, so the body is preserved verbatim on save. Verified via local round-trip. `terms`/home keep the visual (WYSIWYG) editor.
- **Frontmatter normalization:** injected YAML `title` frontmatter into 42 `getting-started/` + `integration-guide/` pages that lacked it (they previously threw `YAMLParseError` because frontmatter-less files with `---` body dividers were misparsed). `_shared/` include-snippets left untouched.
- **Manual publishing:** `backend.skip_ci: true` — CMS saves commit with `[skip ci]` (no auto-deploy). Editors click **"Publish Changes"** in the CMS, which fires `repository_dispatch: sveltia-cms-publish`; `deploy.yml` now listens for it. Edits accumulate and go live only on an explicit publish.
- **UX:** terms entries labeled by filename (many share the title "Terms and Conditions"); `description` field carries a hint (it's the SEO/meta description).

## Remaining one-time setup (out of repo)

1. Register a GitHub OAuth App (org `falcon-protocol`), callback `https://cms-auth.falconlabs.us/callback`.
2. Set worker secrets `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` (in `promo-ad-unit`, `cloudflare-worker/cms-auth/`).
3. Grant editors write access to this repo. (See `public/admin/README.md`.)

## Testing

- Local round-trip (Sveltia local backend) confirmed `modes: [raw]` preserves `@include` / raw HTML / `:::` containers byte-for-byte; only edited text changes.
- `npm run docs:build` passes with all injected frontmatter and includes intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)