### PR TITLE
docs: hashed email/phone, category/subcategory attrs, staging URLs

### DIFF
--- a/integration-guide/_shared/attributes-reference.md
+++ b/integration-guide/_shared/attributes-reference.md
@@ -1,0 +1,32 @@
+Pass user and order data via `attributes` for revenue attribution, offer targeting, and personalization. All values are strings.
+
+| Attribute | Priority | Description | Format |
+| --- | --- | --- | --- |
+| `orderId` | Required | Unique order/transaction identifier. Links the offer impression back to a specific purchase for revenue attribution | String, no special characters (`#`, `@`, `.`, spaces) |
+| `hashedEmail` | Required\* | Customer email, hashed on your end before it's passed in | SHA-256 hex, lowercase, 64 characters |
+| `email` | Required\* | Customer email, plain text. The SDK hashes it in the browser (same SHA-256 algorithm) before anything is sent — nothing leaves the page in the clear | Valid email string |
+| `category` | Optional | Order or product category | String |
+| `subcategory` | Optional | Order or product subcategory | String |
+| `amount` | Recommended | Order total | Numeric string (e.g. `"99.99"`) |
+| `currency` | Optional | Currency code | ISO 4217 (e.g. `"USD"`, `"EUR"`) |
+| `country` | Optional | Customer country | ISO 3166-1 alpha-2 (e.g. `"US"`, `"GB"`) |
+| `language` | Optional | Customer language | ISO 639-1 (e.g. `"en"`, `"fr"`) |
+| `firstname` | Recommended | Customer first name | String |
+| `lastname` | Recommended | Customer last name | String |
+| `hashedPhone` | Optional | Customer phone, hashed on your end before it's passed in | SHA-256 hex, lowercase, 64 characters |
+| `mobile` | Optional | Customer phone, plain text. Hashed in the browser the same way as `email` | String |
+| `age` | Optional | Customer age | Numeric string |
+| `gender` | Optional | Customer gender | String |
+| `billingzipcode` | Optional | Billing ZIP or postal code | String |
+| `billingaddress1` | Optional | Billing address line 1 | String |
+| `billingaddress2` | Optional | Billing address line 2 | String |
+| `cartItems` | Optional | Cart contents | JSON string |
+| `paymenttype` | Optional | Payment method (e.g. `"credit_card"`, `"paypal"`) | String |
+| `ccbin` | Optional | First 6 digits of the credit card number (BIN) | String |
+| `confirmationref` | Optional | Merchant/seller name, or your own internal confirmation reference if separate from `orderId`. Displayed in the offer headline on some templates | String |
+
+\* Pass either `hashedEmail` or `email`, not both. If both are present, `hashedEmail` takes priority. Without one of them (or `orderId`), the SDK still loads and displays offers, but there's nothing to match the impression back to the order, so attribution won't work — this isn't enforced as a hard error, so it's easy to miss during testing.
+
+**Hashed fields:** `hashedEmail` and `hashedPhone` use `trim → lowercase → SHA-256`. Uppercase hex or un-trimmed input will not validate and gets silently dropped rather than erroring, so double check the format before sending.
+
+**Not attributes:** IP address and User-Agent are read automatically from the browser request. State and city are resolved server-side from the visitor's IP, there's no attribute for either. `country` above is only needed if you want to override what's detected (for example, billing country differs from shipping country).

--- a/integration-guide/_shared/odata-api.md
+++ b/integration-guide/_shared/odata-api.md
@@ -58,7 +58,7 @@ Pass customer and order data with the `at.` prefix for better targeting and anal
 - `at.address` (string): Customer address (max 500 chars)
 - `at.zipcode` (string): ZIP/postal code (max 20 chars)
 
-> Email Hashing: For privacy compliance, hash the email using SHA-256 (trim → lowercase → hash) before sending. Use the dedicated `at.hashedEmail` parameter, or pass the hash directly in `at.email` (legacy, still supported — the API detects a valid SHA-256 hex string automatically). Don't send both `at.hashedEmail` and a plaintext `at.email` for the same request.
+> Email Hashing: Send plain-text `at.email` when you can — it gives the best matching and targeting. If privacy or compliance requirements mean you can't send plaintext email, hash it yourself using SHA-256 (trim → lowercase → hash) and send it via the dedicated `at.hashedEmail` parameter, or pass the hash directly in `at.email` (legacy, still supported — the API detects a valid SHA-256 hex string automatically). Don't send both `at.hashedEmail` and a plaintext `at.email` for the same request.
 >
 > Example: `email@example.com` → SHA-256 → `a1b2c3d4e5f6...` (64-character hex string)
 

--- a/integration-guide/_shared/odata-api.md
+++ b/integration-guide/_shared/odata-api.md
@@ -10,6 +10,8 @@ The OData API allows you to fetch promotional offers to display to customers. Th
 GET https://pr-api.falconlabs.us/api/odata
 ```
 
+> **Staging:** Use `https://staging-pr-api.falconlabs.us/api/odata` with your staging public key while testing. See [Staging Environment](/integration-guide/partner-integration/staging-environment) for the full environment reference.
+
 ### Authentication
 
 Use the publisher’s **Public Key**:
@@ -26,12 +28,12 @@ Authorization: Bearer PUBLIC_KEY
 
 - `placementId` (string): Placement ID from placement creation
 - `sessionId` (string): Unique session identifier for the customer (e.g., email or hashed email — distinct from `at.orderid`, which represents a specific order)
-- `at.email` (string): Customer email address (plain or SHA-256 hashed)
+- `at.email` or `at.hashedEmail` (string): Customer email address, plain or SHA-256 hashed
 - `at.orderid` (string): Order ID
 - `at.clientIp` (string): Client IP address (IPv4 or IPv6) — used for geo-targeting
 - `at.userAgent` (string): Client user agent string (max 500 chars) — used for device detection
 
-> Note: At minimum, you must provide placementId, sessionId, and either at.email or at.orderid for proper tracking.
+> Note: `placementId` and `sessionId` are the only parameters the API enforces — a request missing them is rejected. Everything else (`at.orderid`, `at.email`/`at.hashedEmail`, and the rest of the customer/order data parameters below) is not blocked if missing or malformed, the request still succeeds and serves offers. But without at least `at.orderid` and `at.email`/`at.hashedEmail`, there's nothing to match the impression back to a specific order or customer, so revenue attribution won't work even though the request itself "succeeds." Treat them as required in practice.
 
 > Proxying through a server: If you call OData from a backend or proxy rather than directly from the end user's browser, the request's source IP and User-Agent header will be your server's, not the customer's. In that case you must read the original client IP from the `X-Forwarded-For` header (typically the first IP in the list) and the original `User-Agent` header from the inbound request, and forward them explicitly via `at.clientIp` and `at.userAgent`. Otherwise every request will appear to come from your server, breaking geo and device targeting for all users.
 
@@ -45,22 +47,26 @@ Pass customer and order data with the `at.` prefix for better targeting and anal
 
 **Customer Information:**
 
-- `at.email` (string): Customer email address (lowercase, trimmed, or SHA-256 hashed)
+- `at.hashedEmail` (string): Customer email, hashed on your end before sending (SHA-256 hex, lowercase, 64 characters). Takes priority over `at.email` if both are present
+- `at.email` (string): Customer email address, plain text, lowercase, trimmed — or a SHA-256 hash (see Email Hashing below)
+- `at.hashedPhone` (string): Customer phone, hashed the same way as `at.hashedEmail`
 - `at.firstname` or `at.fname` (string): Customer first name
 - `at.lastname` or `at.lname` (string): Customer last name
-- `at.phone` or `at.mobile` (string): Phone number (10-15 digits)
+- `at.phone` or `at.mobile` (string): Phone number, plain text (10-15 digits)
 - `at.country` (string): Country code (ISO format, e.g., “US”, “GB”)
 - `at.language` (string): Language code (e.g., “en”, “es”)
 - `at.address` (string): Customer address (max 500 chars)
 - `at.zipcode` (string): ZIP/postal code (max 20 chars)
 
-> Email Hashing: For privacy compliance, you can hash the email using SHA-256 before sending. Pass the hashed value in at.email parameter. Only SHA-256 hashing is supported.
+> Email Hashing: For privacy compliance, hash the email using SHA-256 (trim → lowercase → hash) before sending. Use the dedicated `at.hashedEmail` parameter, or pass the hash directly in `at.email` (legacy, still supported — the API detects a valid SHA-256 hex string automatically). Don't send both `at.hashedEmail` and a plaintext `at.email` for the same request.
 >
 > Example: `email@example.com` → SHA-256 → `a1b2c3d4e5f6...` (64-character hex string)
 
 **Order Information:**
 
 - `at.orderid` or `at.order_id` (string): Order ID (max 100 chars)
+- `at.category` (string): Order or product category
+- `at.subcategory` (string): Order or product subcategory
 - `at.amount` or `at.ordervalue` (number): Order amount (0-1,000,000)
 - `at.currency` (string): Currency code (e.g., “USD”, “EUR”, “GBP”)
 - `at.billingaddress1` (string): Billing address (max 500 chars)
@@ -74,7 +80,7 @@ USD, EUR, GBP, CAD, AUD, JPY, CNY, NZD, CHF, SEK, NOK, DKK, PLN, CZK, HUF, RON, 
 ### Example Request
 
 ```bash
-curl -X GET "https://pr-api.falconlabs.us/api/odata?placementId=clx4d5e6f7g8h9i0j1k2l3m4n&sessionId=session_abc123&count=4&at.email=customer@example.com&at.firstname=John&at.lastname=Doe&at.orderid=ORDER-12345&at.amount=125.50&at.currency=USD&at.country=US" \
+curl -X GET "https://pr-api.falconlabs.us/api/odata?placementId=clx4d5e6f7g8h9i0j1k2l3m4n&sessionId=session_abc123&count=4&at.email=customer@example.com&at.firstname=John&at.lastname=Doe&at.orderid=ORDER-12345&at.category=Apparel&at.subcategory=Shoes&at.amount=125.50&at.currency=USD&at.country=US" \
   -H "Authorization: Bearer pub_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 ```
 

--- a/integration-guide/embedded.md
+++ b/integration-guide/embedded.md
@@ -25,6 +25,8 @@ Add the Falcon embedded SDK script to your HTML page:
 </head>
 ```
 
+> **Staging:** Use `https://d6y5cd3imay52.cloudfront.net/sdk/staging/embedded-sdk.js` and your staging API key while testing. See [Staging Environment](./partner-integration/staging-environment) for the full URL reference across all three Web SDKs.
+
 ### Step 3: Create HTML Container
 
 Add a container element where the promotional content will render:
@@ -199,8 +201,14 @@ interface FalconAdsConfig {
 interface FalconAdsAttributes {
   /** Unique order identifier (no special characters: #, @, ., spaces) */
   orderId?: string;
-  /** Customer email address */
+  /** Customer email, hashed (SHA-256, lowercase) on your end. Pass this or `email`, not both */
+  hashedEmail?: string;
+  /** Customer email address, plain text. The SDK hashes it in the browser before sending. Pass this or `hashedEmail`, not both */
   email?: string;
+  /** Order or product category */
+  category?: string;
+  /** Order or product subcategory */
+  subcategory?: string;
   /** Order total as a string (e.g. "99.99") */
   amount?: string;
   /** Customer first name */
@@ -221,7 +229,9 @@ interface FalconAdsAttributes {
   paymenttype?: string;
   /** First 6 digits of credit card (BIN) */
   ccbin?: string;
-  /** Customer mobile phone number */
+  /** Customer phone, hashed (SHA-256, lowercase) on your end. Pass this or `mobile`, not both */
+  hashedPhone?: string;
+  /** Customer mobile phone number, plain text. Hashed in the browser the same way as `email` */
   mobile?: string;
   /** Billing address line 1 */
   billingaddress1?: string;
@@ -247,7 +257,9 @@ FalconAds.init({
   placementId: "YOUR_PLACEMENT_ID",
   attributes: {
     orderId: "ORD-123456",
-    email: "customer@example.com",
+    hashedEmail: "SHA256_HEX_OF_EMAIL_LOWERCASE",
+    category: "Electronics",
+    subcategory: "Headphones",
     amount: "99.99",
     currency: "USD",
     firstname: "John",
@@ -261,19 +273,7 @@ FalconAds.init({
 
 ### Attribute Reference
 
-| Attribute        | Priority    | Description             | Format                                          |
-| ---------------- | ----------- | ----------------------- | ----------------------------------------------- |
-| `orderId`        | Required    | Unique order identifier | String, no special characters (#, @, ., spaces) |
-| `email`          | Required    | Customer email          | Valid email string                              |
-| `amount`         | Recommended | Order total             | Numeric string (e.g. `"99.99"`)                 |
-| `firstname`      | Recommended | Customer first name     | String                                          |
-| `lastname`       | Recommended | Customer last name      | String                                          |
-| `currency`       | Optional    | Currency code           | ISO 4217 (e.g. `"USD"`, `"EUR"`)                |
-| `country`        | Optional    | Customer country        | ISO 3166-1 alpha-2 (e.g. `"US"`, `"GB"`)        |
-| `language`       | Optional    | Customer language       | ISO 639-1 (e.g. `"en"`, `"fr"`)                 |
-| `billingzipcode` | Optional    | Billing zip/postal code | String                                          |
-
-> **Note:** All attribute values must be strings. The `attributes` field is optional — the SDK works without it, but passing attributes enables better offer targeting and analytics.
+<!--@include: ./_shared/attributes-reference.md-->
 
 ## Error Handling
 

--- a/integration-guide/gam.md
+++ b/integration-guide/gam.md
@@ -43,6 +43,8 @@ In GAM, go to **Delivery → Creatives → New creative → Custom** and paste t
       amount: "%%PATTERN:amount%%",
       currency: "%%PATTERN:currency%%",
       language: "%%PATTERN:language%%",
+      category: "%%PATTERN:category%%",
+      subcategory: "%%PATTERN:subcategory%%",
     },
   });
 </script>
@@ -50,6 +52,8 @@ In GAM, go to **Delivery → Creatives → New creative → Custom** and paste t
 
 Missing key-values are safe: if a macro is not set on the ad request, the SDK drops the
 unexpanded `%%…%%` value instead of sending it.
+
+> **Staging:** Use `https://d6y5cd3imay52.cloudfront.net/sdk/staging/falcon-gam-sdk.js` in a staging creative, with your staging API key. See [Staging Environment](/integration-guide/partner-integration/staging-environment) for the full URL reference across all Web SDKs.
 
 ### Step 3: Uncheck "Serve into a SafeFrame"
 

--- a/integration-guide/overlay.md
+++ b/integration-guide/overlay.md
@@ -18,7 +18,7 @@ Add this to your **order confirmation page** (or any page where you want to show
 
 ```html
 <head>
-  <script src="<https://falconlabs.s3.us-east-2.amazonaws.com/sdk/falcon-sdk.js>"></script>
+  <script src="https://d6y5cd3imay52.cloudfront.net/sdk/v1/falcon-sdk.js"></script>
   <script>
     (async function () {
       try {
@@ -28,9 +28,9 @@ Add this to your **order confirmation page** (or any page where you want to show
         // 2. Create a placement instance with user/order data
         const perks = FalconSDK.createPerksInstance("YOUR_PLACEMENT_ID", {
           attributes: {
-            email: "user@example.com",
-            firstname: "John",
             orderId: "ORDER-123",
+            hashedEmail: "SHA256_HEX_OF_EMAIL_LOWERCASE",
+            firstname: "John",
             amount: "99.99",
           },
         });
@@ -51,6 +51,10 @@ Add this to your **order confirmation page** (or any page where you want to show
 That's it. The modal will appear with available offers.
 
 > **Get your credentials:** Contact your Falcon Labs account manager to obtain your SDK key and placement ID.
+
+> **Staging:** Point the script tag at `https://d6y5cd3imay52.cloudfront.net/sdk/staging/falcon-sdk.js` and use your staging SDK key while testing. See [Staging Environment](./partner-integration/staging-environment) for the full URL reference across all three Web SDKs.
+>
+> **Legacy link:** Existing integrations using `https://falconlabs.s3.us-east-2.amazonaws.com/sdk/falcon-sdk.js` don't need to migrate, that link is kept up to date in parallel, it just isn't served through CloudFront and has no staging equivalent. New integrations should use the CloudFront URL above.
 
 ## Framework Examples
 
@@ -90,14 +94,14 @@ Show the modal immediately when the component mounts (e.g. order confirmation pa
 
 ```tsx
 // Load the SDK script once in your index.html <head>:
-// <script src="<https://falconlabs.s3.us-east-2.amazonaws.com/sdk/falcon-sdk.js>"></script>
+// <script src="https://d6y5cd3imay52.cloudfront.net/sdk/v1/falcon-sdk.js"></script>
 
 import { useEffect, useRef } from "react";
 
 export function FalconPerksAutoShow({
   sdkKey,
   placementId,
-  userEmail,
+  userHashedEmail,
   userName,
   orderId,
   amount,
@@ -111,9 +115,9 @@ export function FalconPerksAutoShow({
 
         const perks = FalconSDK.createPerksInstance(placementId, {
           attributes: {
-            email: userEmail,
-            firstname: userName,
             orderId,
+            hashedEmail: userHashedEmail,
+            firstname: userName,
             amount,
           },
         });
@@ -134,7 +138,7 @@ export function FalconPerksAutoShow({
     return () => {
       instanceRef.current?.destroy();
     };
-  }, [sdkKey, placementId, userEmail, userName, orderId, amount]);
+  }, [sdkKey, placementId, userHashedEmail, userName, orderId, amount]);
 
   return null;
 }
@@ -150,7 +154,7 @@ import { useEffect, useRef, useCallback } from "react";
 export function FalconPerksButton({
   sdkKey,
   placementId,
-  userEmail,
+  userHashedEmail,
   userName,
   orderId,
   amount,
@@ -164,9 +168,9 @@ export function FalconPerksButton({
 
         instanceRef.current = FalconSDK.createPerksInstance(placementId, {
           attributes: {
-            email: userEmail,
-            firstname: userName,
             orderId,
+            hashedEmail: userHashedEmail,
+            firstname: userName,
             amount,
           },
         });
@@ -180,7 +184,7 @@ export function FalconPerksButton({
     return () => {
       instanceRef.current?.destroy();
     };
-  }, [sdkKey, placementId, userEmail, userName, orderId, amount]);
+  }, [sdkKey, placementId, userHashedEmail, userName, orderId, amount]);
 
   const handleShowPerks = useCallback(async () => {
     if (!instanceRef.current) return;
@@ -207,7 +211,7 @@ The React examples above work in Next.js. The only difference is loading the SDK
 import Script from "next/script";
 
 <Script
-  src="<https://falconlabs.s3.us-east-2.amazonaws.com/sdk/falcon-sdk.js>"
+  src="https://d6y5cd3imay52.cloudfront.net/sdk/v1/falcon-sdk.js"
   strategy="afterInteractive"
 />;
 ```
@@ -216,23 +220,34 @@ Make sure to add `"use client"` to components that use the SDK.
 
 ## Custom Attributes
 
-Pass user and order data for personalized offer targeting. The more attributes you provide, the better the targeting.
+<!--@include: ./_shared/attributes-reference.md-->
 
 ```tsx
 interface CustomAttributes {
-  // Customer email address.
-  // Used for offer personalization and deduplication.
+  // Unique order or transaction identifier.
+  // Links the offer impression to a specific purchase.
+  orderId?: string;
+
+  // Customer email, hashed (SHA-256, lowercase) on your end.
+  // Pass this or `email`, not both.
+  hashedEmail?: string;
+
+  // Customer email address, plain text.
+  // The SDK hashes it in the browser before sending. Pass this or
+  // `hashedEmail`, not both.
   email?: string;
+
+  // Order or product category.
+  category?: string;
+
+  // Order or product subcategory.
+  subcategory?: string;
 
   // Customer first name.
   firstname?: string;
 
   // Customer last name.
   lastname?: string;
-
-  // Unique order or transaction identifier.
-  // Links the offer impression to a specific purchase.
-  orderId?: string;
 
   // Total transaction amount as a string (e.g. "99.99").
   // Used for offer eligibility rules based on order value.
@@ -264,7 +279,12 @@ interface CustomAttributes {
   // Used for card-based offer targeting.
   ccbin?: string;
 
-  // Customer mobile phone number.
+  // Customer phone, hashed (SHA-256, lowercase) on your end.
+  // Pass this or `mobile`, not both.
+  hashedPhone?: string;
+
+  // Customer mobile phone number, plain text.
+  // Hashed in the browser the same way as `email`.
   mobile?: string;
 
   // Billing address line 1.
@@ -376,6 +396,6 @@ The SDK throws on invalid operations. Common errors you may encounter:
 
 **Script doesn't load:**
 
-- Check for ad blockers or CSP rules blocking `falconlabs.s3.us-east-2.amazonaws.com`
+- Check for ad blockers or CSP rules blocking `d6y5cd3imay52.cloudfront.net` (or `falconlabs.s3.us-east-2.amazonaws.com` if you're still on the legacy link)
 
 **Need help?** Contact your Falcon Labs account manager.

--- a/integration-guide/partner-integration/complete-integration-example.md
+++ b/integration-guide/partner-integration/complete-integration-example.md
@@ -6,6 +6,8 @@ title: "Complete Integration Example"
 
 This is a complete walkthrough of the **custom integration path** — creating the entity hierarchy as a partner, then rendering offers yourself by calling OData directly and wiring up the click and impression URLs returned in the response. If you have full control over the surface and don't need to customize rendering, prefer the [Embedded Web SDK](/integration-guide/embedded) — it handles fetching, rendering, impression tracking, and click handling for you. This guide is for cases where you're rendering offers in your own UI.
 
+> Run this against staging first (`https://staging-pr-api.falconlabs.us`) — see [Staging Environment](./staging-environment). The `BASE_URL` below is production; swap it for staging while testing.
+
 ### 1. Create the entity hierarchy
 
 ```bash
@@ -72,7 +74,7 @@ echo "Placement ID:$PLACEMENT_ID"
 ```bash
 echo ""
 echo "Step 4: Fetching offers..."
-curl -s -X GET "${BASE_URL}/api/odata?placementId=${PLACEMENT_ID}&sessionId=test_session_123&count=4&at.email=customer@example.com&at.orderid=ORDER-12345&at.clientIp=203.0.113.42&at.userAgent=Mozilla%2F5.0" \
+curl -s -X GET "${BASE_URL}/api/odata?placementId=${PLACEMENT_ID}&sessionId=test_session_123&count=4&at.hashedEmail=SHA256_HEX_OF_EMAIL_LOWERCASE&at.orderid=ORDER-12345&at.category=Apparel&at.subcategory=Shoes&at.clientIp=203.0.113.42&at.userAgent=Mozilla%2F5.0" \
   -H "Authorization: Bearer${PUBLIC_KEY}" | jq '.'
 
 echo ""

--- a/integration-guide/partner-integration/staging-environment.md
+++ b/integration-guide/partner-integration/staging-environment.md
@@ -18,6 +18,19 @@ title: "Staging Environment"
 
 Contact the Falcon integration team to receive your staging credentials before beginning development.
 
+### Web SDK Script URLs
+
+If you're using one of the Web SDKs ([Overlay](/integration-guide/overlay), [Embedded](/integration-guide/embedded), [Unified](/integration-guide/unified), [Google Ad Manager](/integration-guide/gam)) rather than calling OData directly, load the staging build while testing:
+
+| SDK | Production | Staging |
+| --- | --- | --- |
+| Overlay | `https://d6y5cd3imay52.cloudfront.net/sdk/v1/falcon-sdk.js` | `https://d6y5cd3imay52.cloudfront.net/sdk/staging/falcon-sdk.js` |
+| Embedded | `https://d6y5cd3imay52.cloudfront.net/sdk/v1/embedded-sdk.js` | `https://d6y5cd3imay52.cloudfront.net/sdk/staging/embedded-sdk.js` |
+| Unified | `https://d6y5cd3imay52.cloudfront.net/sdk/v1/unified-sdk.js` | `https://d6y5cd3imay52.cloudfront.net/sdk/staging/unified-sdk.js` |
+| Google Ad Manager | `https://d6y5cd3imay52.cloudfront.net/sdk/v1/falcon-gam-sdk.js` | `https://d6y5cd3imay52.cloudfront.net/sdk/staging/falcon-gam-sdk.js` |
+
+> The Overlay SDK also has a legacy raw-S3 link (`https://falconlabs.s3.us-east-2.amazonaws.com/sdk/falcon-sdk.js`, production only, no staging equivalent) kept for existing integrations. New integrations should use the CloudFront URL above, which has a staging counterpart and sits behind the CDN.
+
 ### Technical Requirements
 
 - HTTPS-capable server for API calls

--- a/integration-guide/unified.md
+++ b/integration-guide/unified.md
@@ -26,6 +26,8 @@ On each `init()` call the SDK:
 <script src="https://d6y5cd3imay52.cloudfront.net/sdk/v1/unified-sdk.js"></script>
 ```
 
+> **Staging:** Use `https://d6y5cd3imay52.cloudfront.net/sdk/staging/unified-sdk.js` and your staging API key while testing. See [Staging Environment](./partner-integration/staging-environment) for the full URL reference across all three Web SDKs.
+
 ### Step 2: Add a Container Element
 
 A container is required regardless of which mode Falcon selects — it's the render target for embedded mode and must exist in the DOM before `init()` is called.
@@ -49,6 +51,26 @@ FalconUnifiedAds.init({
 ```
 
 That's it. The SDK loads and displays offers in whichever format Falcon assigns to this user.
+
+### With Order Attributes
+
+Pass order and customer data via `attributes` for revenue attribution and offer targeting — see the [Embedded guide's attribute reference](./embedded#attribute-reference) for the full field list:
+
+```javascript
+FalconUnifiedAds.init({
+  apiKey: "YOUR_API_KEY",
+  containerId: "falcon-ads-container",
+  placementId: "YOUR_PLACEMENT_ID",
+  attributes: {
+    orderId: "ORD-123456",
+    hashedEmail: "SHA256_HEX_OF_EMAIL_LOWERCASE",
+    category: "Electronics",
+    subcategory: "Headphones",
+    amount: "99.99",
+    currency: "USD",
+  },
+});
+```
 
 ## API Reference
 


### PR DESCRIPTION
Adds `hashedEmail`/`hashedPhone` (SHA-256) as the preferred alternative to plaintext `email`/`mobile` across the OData API and all Web SDK guides (Overlay, Embedded, Unified, GAM), plus new `category`/`subcategory` order attributes. Clarifies which OData/attribute fields are actually enforced by the API versus merely required in practice for revenue attribution. Adds a staging environment URL table and per-guide staging callouts for all Web SDKs, and updates the Overlay SDK script tag to the CloudFront URL (noting the legacy S3 link still works). Introduces a shared `_shared/attributes-reference.md` include, consumed by both `embedded.md` and `overlay.md`, to de-duplicate the attribute table.

## Test plan
- [ ] Spot-check rendered docs site for the `_shared/attributes-reference.md` include in `embedded.md` and `overlay.md`
- [ ] Verify staging vs. production SDK URLs in `staging-environment.md` match actual CloudFront paths