### PR TITLE
docs: document at.correlationId for mediation-integrated OData API

### DIFF
--- a/integration-guide/_shared/odata-api.md
+++ b/integration-guide/_shared/odata-api.md
@@ -40,6 +40,7 @@ Authorization: Bearer PUBLIC_KEY
 ### Optional Parameters
 
 - `count` (number, default: 4): Number of offers to return
+- `at.correlationId` (string): Mediation correlation ID. Required in practice when the API is integrated through Falcon Mediation.
 
 ### Customer Data Parameters
 


### PR DESCRIPTION
## Summary

Documents the `at.correlationId` query parameter on the publisher OData API, for the case where the API is integrated via Falcon Mediation.

Added under **Optional Parameters** in `integration-guide/_shared/odata-api.md` (the shared partial included by `integration-guide/publisher-integration/odata-api.md`).

## Contract verified against promo-ad-unit

- `extractCorrelationId` — `backend/src/analytics.ts:494-520`; pattern `/^[A-Za-z0-9._-]{1,64}$/`, case-insensitive, tolerant of doubled `at.` prefixes
- Invalid value resolves to `null` rather than being truncated or sanitized; the request still succeeds
- Persisted as `Request.correlationId` (nullable, indexed) — `backend/schema.prisma`
- Never returned in the OData response body
- Stripped for GDPR users — `backend/src/shared/gdpr-pii.ts`
- Used as the join key for the revenue-event feed back to mediation — `backend/src/revenue-feed/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)