### PR TITLE
docs: transactions now count only orders where the offer was seen

### DIFF
--- a/integration-guide/_shared/reporting-api.md
+++ b/integration-guide/_shared/reporting-api.md
@@ -73,7 +73,7 @@ The core fields (`date`, `clicks`, `transactions`, `revenue`, `site`, `siteId`) 
 | --- | --- | --- | --- |
 | `date` | string | Always | Format depends on `breakdownBy` — see below |
 | `clicks` | number | Always | Number of clicks on offers |
-| `transactions` | number | Always | Event count of requests that resulted in postback/conversion tracking |
+| `transactions` | number | Always | Orders attributed to your placements where the offer was actually seen — see [How transactions are counted](#how-transactions-are-counted) |
 | `revenue` | number | Always | Revenue generated. This is the only revenue field returned |
 | `site` | string | Always | Site name |
 | `siteId` | string | Always | |
@@ -82,6 +82,29 @@ The core fields (`date`, `clicks`, `transactions`, `revenue`, `site`, `siteId`) 
 | `country` | string \| null | When grouped by `COUNTRY` | ISO country code, or `null` when unknown |
 
 > **`date` format:** when `breakdownBy` is `NONE` (the default), `date` is the report's start date in `YYYY-MM-DD` form (e.g. `"2024-01-01"`). For any time breakdown (`DAY`, `WEEK`, `MONTH`), `date` is formatted as `DD/MM/YYYY` (e.g. `"15/01/2024"`).
+
+### How transactions are counted
+
+A `transactions` row counts an order **only if the offer was actually shown to the shopper on that order's ad request**:
+
+- **Web SDK** — the offer must have been *viewed*, meaning it met the IAB/MRC standard of at least 50% of the creative visible for at least one second. An offer that rendered below the fold and was never scrolled to does **not** count.
+- **All other integrations** — the offer must have registered an impression.
+
+An order placed on a page where the offer never rendered, or never came into view, is not counted.
+
+**Effective 15 August 2026.** Reports covering dates before then use the previous definition, which counted every attributed order regardless of whether the offer was seen. Historical figures have not been restated, so a report spanning that date contains both definitions.
+
+**What changed for you.** Reported transaction counts are lower from that date, and because revenue is unaffected, revenue-per-transaction is correspondingly higher. Your revenue does not change as a result of this. The size of the shift depends on how much of your traffic saw the offer.
+
+If your transaction counts dropped further than you expected, the usual cause is impressions not being reported — see [Making sure your impressions are counted](#making-sure-your-impressions-are-counted).
+
+### Making sure your impressions are counted
+
+Because transactions now depend on impressions, an integration that does not report impressions reliably will under-report transactions.
+
+- If you call the ad-serving API directly, you must call the offer's `beaconUrl` when the offer is displayed. Skipping it means the order is not counted as a transaction.
+- If you have set `disableClientImpressions`, confirm your server-side impression calls are firing for every displayed offer.
+- On Web SDK, offers rendered outside the viewport will not reach the viewed threshold. Placements positioned below the fold will legitimately show fewer transactions than the number of orders.
 
 ### Example Requests
 
@@ -115,7 +138,7 @@ The response is a bare array of row objects:
   {
     "date": "15/01/2024",
     "clicks": 85,
-    "transactions": 1250,
+    "transactions": 980,
     "revenue": 450.5,
     "placementId": "clx4d5e6f7g8h9i0j1k2l3m4n",
     "placement": "Thank You Page Placement",
@@ -126,7 +149,7 @@ The response is a bare array of row objects:
   {
     "date": "16/01/2024",
     "clicks": 96,
-    "transactions": 1420,
+    "transactions": 1115,
     "revenue": 562.75,
     "placementId": "clx4d5e6f7g8h9i0j1k2l3m4n",
     "placement": "Thank You Page Placement",

--- a/integration-guide/partner-integration/complete-integration-example.md
+++ b/integration-guide/partner-integration/complete-integration-example.md
@@ -130,6 +130,6 @@ function renderOffer(offer, container) {
 }
 ```
 
-> Important: Skipping the impression beacon means Falcon never records that the offer was viewed, which breaks attribution and reporting. Skipping the click URL means clicks aren't recorded and the customer won't be redirected to the advertiser. Both are required for a custom integration to be considered complete.
+> Important: Skipping the impression beacon means Falcon never records that the offer was viewed. Since 15 August 2026 that also means the resulting order is not counted as a transaction in your reports. See [How transactions are counted](/integration-guide/partner-integration/reporting-api#how-transactions-are-counted). Skipping the click URL means clicks aren't recorded and the customer won't be redirected to the advertiser. Both are required for a custom integration to be considered complete.
 
 For the full event semantics — including the JSON variants and required parameters — see the [Impression API](./impression-api) and [Click API](./click-api) docs.

--- a/integration-guide/partner-integration/frequently-asked-questions.md
+++ b/integration-guide/partner-integration/frequently-asked-questions.md
@@ -34,7 +34,7 @@ title: "Frequently Asked Questions"
 
 ### Q: Do I need to implement impression tracking?
 
-**A**: Yes, call the `beaconUrl` when an offer is displayed to track impressions. This is critical for accurate reporting and campaign optimization.
+**A**: Yes, call the `beaconUrl` when an offer is displayed to track impressions. Since 15 August 2026 an order is only counted as a transaction if its offer was actually seen, so if you do not report impressions your transactions will not be counted at all. See [How transactions are counted](/integration-guide/partner-integration/reporting-api#how-transactions-are-counted).
 
 ### Q: Why am I only seeing test/mock offers instead of real ones?
 


### PR DESCRIPTION
Publisher-facing counterpart to falcon-dbt#60 / #61 and promo-ad-unit#1190 (FAL-2490).

## Why

The public definition of the `transactions` field was wrong, and would have stayed wrong through a change that moves the number ~26%:

> `transactions` | number | Always | **Event count of requests that resulted in postback/conversion tracking**

That describes neither the old behaviour (attributed orders, not postbacks) nor the new one. From **15 August 2026** an order counts only if its ad request produced an impression - and on Web SDK only if the offer was actually *viewed* (IAB/MRC, 50% for 1s).

Both published Reporting API pages (`/integration-guide/reporting-api` and `/integration-guide/partner-integration/reporting-api`) are includes of the one shared file, so this fixes both at once.

## Changes

- Rewrite the field definition, and add **How transactions are counted**: the Web SDK vs other-integrations split, the effective date, and the fact that history is **not** restated - so a report spanning 15 Aug contains both definitions.
- Say plainly that **revenue does not change as a result of this.** "My transactions dropped 26%" reads as a revenue cut unless we get ahead of it.
- Add **Making sure your impressions are counted**, aimed at the integrations that will drop hardest: direct API callers who skip `beaconUrl`, anyone running `disableClientImpressions`, and below-the-fold Web SDK placements that never reach the viewed threshold.
- Upgrade two warnings that said skipping the beacon "breaks attribution and reporting". It now also means the order is not counted as a transaction at all.
- Re-base the sample `transactions` values, which implied an RPT well below what publishers will now see.

## Deliberately not here

- **No changelog / release-notes page.** Neither docs repo has one, so there is currently no publisher-facing channel to announce a metric-definition change. Creating one is worth doing but is a product/comms decision, not a docs fix.
- **No public RPT definition.** There is no published RPT formula anywhere in either repo, so there was nothing to correct - but also nothing to point publishers at when they ask why RPT rose ~36%. Flagging as a gap.
- `falcon-protocol/docs` (Falcon Perks) has zero reporting-API content and needs no changes.

## Worth checking before merge

- `crud-api-site.md` `?stats=true` publishes `totalImpressions` / `revenue` but no transactions. Confirm it is computed on the same basis, since it is where a publisher would try to reconcile the drop.
- The CTR note says CTR is "clicks over ad impressions". Confirm that denominator matches the new impression basis.

Timing: merge alongside the cutover going live, not before - the effective date is stated as 15 August 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)