### PR TITLE
fix: update Sveltia CMS to 0.200.0 to restore content loading

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -6,6 +6,6 @@
     <title>Content Manager</title>
   </head>
   <body>
-    <script src="https://unpkg.com/@sveltia/cms@0.120.1/dist/sveltia-cms.js" type="module"></script>
+    <script src="https://unpkg.com/@sveltia/cms@0.200.0/dist/sveltia-cms.js" type="module"></script>
   </body>
 </html>


### PR DESCRIPTION
## Problem

The CMS admin (`/admin/`) shows **no content on any page**. Collections list the correct entry counts (Partner Integration: 19, Terms: 15, …) and the editor header shows each entry's filename, but **Title, Description, and Body are all empty** across every collection.

That signature — file *tree* loads (names/counts) but file *contents* don't — means Sveltia's GitHub content-fetch is failing globally. (A parse bug would still render the raw Body; all-three-empty means nothing was fetched.)

## Root cause

`public/admin/index.html` pinned `@sveltia/cms@0.120.1`, released **2025-11-27 (~9 months stale)**. The CMS was working as recently as Aug 14 (it authored the "Create Terms page 'polymarket'" commit), so nothing in the repo broke — GitHub changed something on their API that a 9-month-old bundle can no longer complete, and content fetch now returns empty.

Ruled out: content files are valid on disk, `config.yml` is valid YAML, total content is only ~379 KB / 83 files (well under any API batch limit), and auth works (listing succeeds).

## Fix

Bump the pin to the current release:

```
@sveltia/cms@0.120.1  →  @sveltia/cms@0.200.0
```

## Verification

- New bundle URL resolves (HTTP 200).
- ⚠️ Large jump (0.120 → 0.200); the authenticated CMS can't be exercised from CI. After deploy, hard-refresh `docs.falconlabs.us/admin/`, confirm entries show titles/bodies, and smoke-test one edit + Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)