### PR TITLE
docs: add at.shippingAmount OData parameter

### DIFF
--- a/integration-guide/_shared/odata-api.md
+++ b/integration-guide/_shared/odata-api.md
@@ -69,6 +69,7 @@ Pass customer and order data with the `at.` prefix for better targeting and anal
 - `at.category` (string): Order or product category
 - `at.subcategory` (string): Order or product subcategory
 - `at.amount` or `at.ordervalue` (number): Order amount (0-1,000,000)
+- `at.shippingAmount` (number): Total shipping amount for the order (0-1,000,000)
 - `at.currency` (string): Currency code (e.g., “USD”, “EUR”, “GBP”)
 - `at.billingaddress1` (string): Billing address (max 500 chars)
 - `at.billingzipcode` (string): Billing ZIP code (max 20 chars)


### PR DESCRIPTION
## What

Adds `at.shippingAmount` as a supported **Order Information** parameter in the shared OData API reference (`integration-guide/_shared/odata-api.md`), describing the total shipping amount for the order.

Placed directly after `at.amount`, matching the existing numeric-amount style and `0-1,000,000` range.

```
- `at.amount` or `at.ordervalue` (number): Order amount (0-1,000,000)
+ `at.shippingAmount` (number): Total shipping amount for the order (0-1,000,000)
- `at.currency` (string): Currency code (e.g., "USD", "EUR", "GBP")
```

This file is a `_shared` snippet, so the new parameter appears everywhere the OData reference is embedded via `<!--@include-->`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)